### PR TITLE
Remove packet read timeout to fix no traffic error on MacOS

### DIFF
--- a/src/os/lsof_utils.rs
+++ b/src/os/lsof_utils.rs
@@ -62,7 +62,7 @@ impl RawConnection {
 }
 
 pub fn get_connections<'a>() -> RawConnections {
-    let content = run(&["-n", "-P", "-i4", "+c", "30"]);
+    let content = run(&["-n", "-P", "-i4"]);
     RawConnections::new(content)
 }
 

--- a/src/os/lsof_utils.rs
+++ b/src/os/lsof_utils.rs
@@ -62,7 +62,7 @@ impl RawConnection {
 }
 
 pub fn get_connections<'a>() -> RawConnections {
-    let content = run(&["-n", "-P", "-i4"]);
+    let content = run(&["-n", "-P", "-i4", "+c", "30"]);
     RawConnections::new(content)
 }
 

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -34,7 +34,9 @@ fn get_datalink_channel(
     interface: &NetworkInterface,
 ) -> Result<Box<dyn DataLinkReceiver>, failure::Error> {
     let mut config = Config::default();
-    config.read_timeout = Some(time::Duration::new(0, 2_000_000));
+    if cfg!(not(target_os = "macos")) {
+        config.read_timeout = Some(time::Duration::new(2, 0));
+    }
     match datalink::channel(interface, config) {
         Ok(Ethernet(_tx, rx)) => Ok(rx),
         Ok(_) => failure::bail!("Unknown interface type"),


### PR DESCRIPTION
Fix issue #51 , as discussed, removing the read timeout fixed the issue. With the timeout removed, I can still press `q` to exit the program, or CTRL-C.

