### PR TITLE
Mention `setcap` to set the binary capability on `bandwhich`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yay -S bandwhich
 cargo install bandwhich
 ```
 
-If you're on linux, you could also get the generic binary from the releases.
+If you're on Linux, you could also get the generic binary from the releases.
 
 Windows is not supported at the moment - if you'd like to contribute a windows port, it would be very much welcome.
 
@@ -40,7 +40,13 @@ OPTIONS:
     -i, --interface <interface>    The network interface to listen on, eg. eth0
 ```
 
-Note that since `bandwhich` sniffs network packets, it requires root privileges - so you might want to use it with (for example) `sudo`.
+**Note that since `bandwhich` sniffs network packets, it requires root privileges** - so you might want to use it with (for example) `sudo`.
+
+On Linux, you can give the `bandwhich` binary a permanent capability to use the required privileges, so that you don't need to use `sudo bandwhich` anymore:
+
+```bash
+sudo setcap cap_net_raw,cap_net_admin=+ep "$HOME/.cargo/bin/bandwhich"
+```
 
 ### raw_mode
 `bandwhich` also supports an easier-to-parse mode that can be piped or redirected to a file. For example, try:
@@ -53,7 +59,7 @@ Contributions of any kind are very welcome. If you'd like a new feature (or foun
 To set up your development environment:
 1. Clone the project
 2. `cargo run`, or if you prefer `cargo run -- -i <network interface name>` (you can often find out the name with `ifconfig` or `iwconfig`). You might need root privileges to run this application, so be sure to use (for example) sudo.
-    
+
 To run tests: `cargo test`
 
 Note that at the moment the tests do not test the os layer (anything in the `os` folder).


### PR DESCRIPTION
See #30.

This also boldens the part that mentions root privileges are required to make it easier to notice.