### PR TITLE
Add spacing between the up and down bandwidth values for readability

### DIFF
--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -16,13 +16,13 @@ const FIRST_WIDTH_BREAKPOINT: u16 = 50;
 const SECOND_WIDTH_BREAKPOINT: u16 = 71;
 const THIRD_WIDTH_BREAKPOINT: u16 = 95;
 
-const FIRST_COLUMN_WIDTHS: [u16; 4] = [20, 30, 40, 50];
+const FIRST_COLUMN_WIDTHS: [u16; 4] = [10, 30, 40, 50];
 const SECOND_COLUMN_WIDTHS: [u16; 1] = [20];
-const THIRD_COLUMN_WIDTHS: [u16; 4] = [10, 20, 20, 20];
+const THIRD_COLUMN_WIDTHS: [u16; 4] = [20, 20, 20, 20];
 
 fn display_upload_and_download(bandwidth: &impl Bandwidth) -> String {
     format!(
-        "{}/{}",
+        "{} / {}",
         DisplayBandwidth(bandwidth.get_total_bytes_uploaded() as f64),
         DisplayBandwidth(bandwidth.get_total_bytes_downloaded() as f64)
     )
@@ -75,7 +75,7 @@ impl<'a> Table<'a> {
             })
             .collect();
         let connections_title = "Utilization by connection";
-        let connections_column_names = &["Connection", "Process", "Rate Up/Down"];
+        let connections_column_names = &["Connection", "Process", "Rate Up / Down"];
         Table {
             title: connections_title,
             column_names: connections_column_names,
@@ -96,7 +96,7 @@ impl<'a> Table<'a> {
             })
             .collect();
         let processes_title = "Utilization by process name";
-        let processes_column_names = &["Process", "Connection count", "Rate Up/Down"];
+        let processes_column_names = &["Process", "Connection count", "Rate Up / Down"];
         Table {
             title: processes_title,
             column_names: processes_column_names,
@@ -121,7 +121,8 @@ impl<'a> Table<'a> {
             })
             .collect();
         let remote_addresses_title = "Utilization by remote address";
-        let remote_addresses_column_names = &["Remote Address", "Connection Count", "Rate Up/Down"];
+        let remote_addresses_column_names =
+            &["Remote Address", "Connection Count", "Rate Up / Down"];
         Table {
             title: remote_addresses_title,
             column_names: remote_addresses_column_names,

--- a/src/display/components/total_bandwidth.rs
+++ b/src/display/components/total_bandwidth.rs
@@ -14,7 +14,7 @@ impl<'a> TotalBandwidth<'a> {
     pub fn render(&self, frame: &mut Frame<impl Backend>, rect: Rect) {
         let title_text = [Text::styled(
             format!(
-                " Total Rate Up/Down: {}/{}",
+                " Total Rate Up / Down: {} / {}",
                 DisplayBandwidth(self.state.total_bytes_uploaded as f64),
                 DisplayBandwidth(self.state.total_bytes_downloaded as f64)
             ),

--- a/src/tests/cases/snapshots/ui__basic_startup.snap
+++ b/src/tests/cases/snapshots/ui__basic_startup.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                     49Bps/51Bps                                                                                                                                                              
+                       49Bps / 51Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     49Bps/51Bps          <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     49Bps/51Bps         
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     49Bps / 51Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     49Bps / 51Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     49Bps/51Bps         
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     49Bps / 51Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
@@ -2,14 +2,14 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          184Bps                                                                                                                                                              
+                              184Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 4                                                   1                     0Bps/53Bps           <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/53Bps          
- 5                                                   1                     0Bps/45Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/45Bps          
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
- 2                                                   1                     0Bps/42Bps           <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps/42Bps          
+ 4                                                   1                     0Bps / 53Bps         <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps / 53Bps        
+ 5                                                   1                     0Bps / 45Bps         <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps / 45Bps        
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 2                                                   1                     0Bps / 42Bps         <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps / 42Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
@@ -2,18 +2,14 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          184Bps                                                                                       
+                              184Bps                                                                                   
                                                                                                                        
                                                                                                                        
                                                                                                                        
- 4                                                   1                     0Bps/53Bps                                  
- 5                                                   1                     0Bps/45Bps                                  
- 1                                                   1                     0Bps/44Bps                                  
- 2                                                   1                     0Bps/42Bps                                  
-                                                                                                                       
-                                                                                                                       
-                                                                                                                       
-                                                                                                                       
+ 4                                                   1                     0Bps / 53Bps                                
+ 5                                                   1                     0Bps / 45Bps                                
+ 1                                                   1                     0Bps / 44Bps                                
+ 2                                                   1                     0Bps / 42Bps                                
                                                                                                                        
                                                                                                                        
                                                                                                                        
@@ -30,10 +26,14 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                        
                                                                                                                        
                                                                                                                        
- <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/53Bps                                  
- <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/45Bps                                  
- <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps                                  
- <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps/42Bps                                  
+                                                                                                                       
+                                                                                                                       
+                                                                                                                       
+                                                                                                                       
+ <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps / 53Bps                                
+ <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps / 45Bps                                
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps                                
+ <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps / 42Bps                                
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                         
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                     
 ┌Utilization by process name──────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down                               │
+│Process                                             Connection count      Rate Up / Down                             │
 │                                                                                                                     │
 │                                                                                                                     │
 │                                                                                                                     │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                                                     │
 └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                          Process               Rate Up/Down                               │
+│Connection                                          Process               Rate Up / Down                             │
 │                                                                                                                     │
 │                                                                                                                     │
 │                                                                                                                     │

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
@@ -2,14 +2,14 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          184Bps                                                                                       
+                              184Bps                                                                                   
                                                                                                                        
                                                                                                                        
                                                                                                                        
- 4                                                   1                     0Bps/53Bps                                  
- 5                                                   1                     0Bps/45Bps                                  
- 1                                                   1                     0Bps/44Bps                                  
- 2                                                   1                     0Bps/42Bps                                  
+ 4                                                   1                     0Bps / 53Bps                                
+ 5                                                   1                     0Bps / 45Bps                                
+ 1                                                   1                     0Bps / 44Bps                                
+ 2                                                   1                     0Bps / 42Bps                                
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                         
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                     
 ┌Utilization by process name──────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down                               │
+│Process                                             Connection count      Rate Up / Down                             │
 │                                                                                                                     │
 │                                                                                                                     │
 │                                                                                                                     │

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
@@ -2,18 +2,14 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          184Bps                                                                                                                     
+                              184Bps                                                                                                                 
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- 4                                                   1                     0Bps/53Bps                                                                
- 5                                                   1                     0Bps/45Bps                                                                
- 1                                                   1                     0Bps/44Bps                                                                
- 2                                                   1                     0Bps/42Bps                                                                
-                                                                                                                                                     
-                                                                                                                                                     
-                                                                                                                                                     
-                                                                                                                                                     
+ 4                                                   1                     0Bps / 53Bps                                                              
+ 5                                                   1                     0Bps / 45Bps                                                              
+ 1                                                   1                     0Bps / 44Bps                                                              
+ 2                                                   1                     0Bps / 42Bps                                                              
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
@@ -30,10 +26,14 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- <interface_name>:443 => 2.2.2.2:54321 (t  0Bps/53Bps                      2.2.2.2                                   0Bps/53Bps                      
- <interface_name>:443 => 3.3.3.3:1337 (tc  0Bps/45Bps                      3.3.3.3                                   0Bps/45Bps                      
- <interface_name>:443 => 1.1.1.1:12345 (t  0Bps/44Bps                      1.1.1.1                                   0Bps/44Bps                      
- <interface_name>:443 => 4.4.4.4:1337 (tc  0Bps/42Bps                      4.4.4.4                                   0Bps/42Bps                      
+                                                                                                                                                     
+                                                                                                                                                     
+                                                                                                                                                     
+                                                                                                                                                     
+ <interface_name>:443 => 2.2.2.2:54321 (t  0Bps / 53Bps                    2.2.2.2                                   0Bps / 53Bps                    
+ <interface_name>:443 => 3.3.3.3:1337 (tc  0Bps / 45Bps                    3.3.3.3                                   0Bps / 45Bps                    
+ <interface_name>:443 => 1.1.1.1:12345 (t  0Bps / 44Bps                    1.1.1.1                                   0Bps / 44Bps                    
+ <interface_name>:443 => 4.4.4.4:1337 (tc  0Bps / 42Bps                    4.4.4.4                                   0Bps / 42Bps                    
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_full_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_full_height.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                       
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                   
 ┌Utilization by process name────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down                                                             │
+│Process                                             Connection count      Rate Up / Down                                                           │
 │                                                                                                                                                   │
 │                                                                                                                                                   │
 │                                                                                                                                                   │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                                                                                   │
 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────┐
-│Connection                                Rate Up/Down                  ││Remote Address                            Rate Up/Down                   │
+│Connection                                Rate Up / Down                ││Remote Address                            Rate Up / Down                 │
 │                                                                        ││                                                                         │
 │                                                                        ││                                                                         │
 │                                                                        ││                                                                         │

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
@@ -2,14 +2,14 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          184Bps                                                                                                                     
+                              184Bps                                                                                                                 
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- 4                                         0Bps/53Bps                      <interface_name>:443 => 2.2.2.2:54321 (t  0Bps/53Bps                      
- 5                                         0Bps/45Bps                      <interface_name>:443 => 3.3.3.3:1337 (tc  0Bps/45Bps                      
- 1                                         0Bps/44Bps                      <interface_name>:443 => 1.1.1.1:12345 (t  0Bps/44Bps                      
- 2                                         0Bps/42Bps                      <interface_name>:443 => 4.4.4.4:1337 (tc  0Bps/42Bps                      
+ 4                                         0Bps / 53Bps                    <interface_name>:443 => 2.2.2.2:54321 (t  0Bps / 53Bps                    
+ 5                                         0Bps / 45Bps                    <interface_name>:443 => 3.3.3.3:1337 (tc  0Bps / 45Bps                    
+ 1                                         0Bps / 44Bps                    <interface_name>:443 => 1.1.1.1:12345 (t  0Bps / 44Bps                    
+ 2                                         0Bps / 42Bps                    <interface_name>:443 => 4.4.4.4:1337 (tc  0Bps / 42Bps                    
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                       
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                   
 ┌Utilization by process name─────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────┐
-│Process                                   Rate Up/Down                  ││Connection                                Rate Up/Down                   │
+│Process                                   Rate Up / Down                ││Connection                                Rate Up / Down                 │
 │                                                                        ││                                                                         │
 │                                                                        ││                                                                         │
 │                                                                        ││                                                                         │

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          95Bps                                                                                                                                                               
+                              95Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 3                                                   1                     0Bps/51Bps           <interface_name>:443 => 1.1.1.1:12346 (tcp)         3                     0Bps/51Bps          
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 3                                                   1                     0Bps / 51Bps         <interface_name>:443 => 1.1.1.1:12346 (tcp)         3                     0Bps / 51Bps        
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             2                     0Bps/95Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             2                     0Bps / 95Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          83Bps                                                                                                                                                               
+                              83Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
- 4                                                   1                     0Bps/39Bps           <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/39Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 4                                                   1                     0Bps / 39Bps         <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps / 39Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps/44Bps          
-                                                                                                2.2.2.2                                             1                     0Bps/39Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
+                                                                                                2.2.2.2                                             1                     0Bps / 39Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          91Bps                                                                                                                                                               
+                              91Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/91Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/91Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     0Bps / 91Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 91Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps/91Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     0Bps / 91Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
@@ -2,18 +2,14 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          184Bps                                                                                                                                                              
+                              184Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 4                                                   1                     0Bps/53Bps           <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps/53Bps          
- 5                                                   1                     0Bps/45Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/45Bps          
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
- 2                                                   1                     0Bps/42Bps           <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps/42Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 4                                                   1                     0Bps / 53Bps         <interface_name>:443 => 2.2.2.2:54321 (tcp)         4                     0Bps / 53Bps        
+ 5                                                   1                     0Bps / 45Bps         <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps / 45Bps        
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 2                                                   1                     0Bps / 42Bps         <interface_name>:443 => 4.4.4.4:1337 (tcp)          2                     0Bps / 42Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,10 +26,14 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                2.2.2.2                                             1                     0Bps/53Bps          
-                                                                                                3.3.3.3                                             1                     0Bps/45Bps          
-                                                                                                1.1.1.1                                             1                     0Bps/44Bps          
-                                                                                                4.4.4.4                                             1                     0Bps/42Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                2.2.2.2                                             1                     0Bps / 53Bps        
+                                                                                                3.3.3.3                                             1                     0Bps / 45Bps        
+                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
+                                                                                                4.4.4.4                                             1                     0Bps / 42Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                     69    82                                                                                                                                                                 
+                       69      82                                                                                                                                                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32    46                                     3 3 3 3  3 7 (tcp)          5                     32    46            
- 1                                                                          7     6                                     1 1 1 1  2 45 (tcp)         1                      7     6            
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 5                                                                         32      46                                   3 3 3 3  3 7 (tcp)          5                     32      46          
+ 1                                                                          7       6                                   1 1 1 1  2 45 (tcp)         1                      7       6          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                3 3 3 3                                                                   32    46            
-                                                                                                1 1 1 1                                                                    7     6            
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                3 3 3 3                                                                   32      46          
+                                                                                                1 1 1 1                                                                    7       6          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                     91Bps/98Bps                                                                                                                                                              
+                       91Bps / 98Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps/61Bps          <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps/61Bps         
- 5                                                   1                     34Bps/37Bps          <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     34Bps/37Bps         
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     57Bps / 61Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps / 61Bps       
+ 5                                                   1                     34Bps / 37Bps        <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     34Bps / 37Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     57Bps/61Bps         
-                                                                                                3.3.3.3                                             1                     34Bps/37Bps         
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     57Bps / 61Bps       
+                                                                                                3.3.3.3                                             1                     34Bps / 37Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                     42Bps/0Bps                                                                                                                                                               
+                       42Bps / 0Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     42Bps/0Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps/0Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     42Bps / 0Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     42Bps/0Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     42Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          92Bps                                                                                                                                                               
+                              92Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                   1                     0Bps/48Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/48Bps          
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 5                                                   1                     0Bps / 48Bps         <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps / 48Bps        
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                3.3.3.3                                             1                     0Bps/48Bps          
-                                                                                                1.1.1.1                                             1                     0Bps/44Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                3.3.3.3                                             1                     0Bps / 48Bps        
+                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                          112Bps                                                                                                                                                              
+                              112Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                61                                                                                             61             
-                                                                                51                                                                                             51             
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                                  61                                                                                             61           
+                                                                                  51                                                                                             51           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                                               61             
-                                                                                                                                                                               51             
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                 61           
+                                                                                                                                                                                 51           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          83Bps                                                                                                                                                               
+                              83Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
- 5                                                   1                     0Bps/39Bps           <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps/39Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 5                                                   1                     0Bps / 39Bps         <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     0Bps / 39Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps/44Bps          
-                                                                                                3.3.3.3                                             1                     0Bps/39Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
+                                                                                                3.3.3.3                                             1                     0Bps / 39Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                     69    82                                                                                                                                                                 
+                       69      82                                                                                                                                                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32    46                                     3 3 3 3  3 7 (tcp)          5                     32    46            
- 1                                                                          7     6                                     1 1 1 1  2 45 (tcp)         1                      7     6            
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 5                                                                         32      46                                   3 3 3 3  3 7 (tcp)          5                     32      46          
+ 1                                                                          7       6                                   1 1 1 1  2 45 (tcp)         1                      7       6          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                3 3 3 3                                                                   32    46            
-                                                                                                1 1 1 1                                                                    7     6            
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                3 3 3 3                                                                   32      46          
+                                                                                                1 1 1 1                                                                    7       6          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                     91Bps/98Bps                                                                                                                                                              
+                       91Bps / 98Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps/61Bps          <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps/61Bps         
- 5                                                   1                     34Bps/37Bps          <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     34Bps/37Bps         
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     57Bps / 61Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps / 61Bps       
+ 5                                                   1                     34Bps / 37Bps        <interface_name>:443 => 3.3.3.3:1337 (tcp)          5                     34Bps / 37Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     57Bps/61Bps         
-                                                                                                3.3.3.3                                             1                     34Bps/37Bps         
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     57Bps / 61Bps       
+                                                                                                3.3.3.3                                             1                     34Bps / 37Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                          51                                                                                                                                                                  
+                              51                                                                                                                                                              
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                51                                                                                             51             
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                                  51                                                                                             51           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                                               51             
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                 51           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                          44Bps                                                                                                                                                               
+                              44Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps/44Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps/44Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps/44Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                     69    82                                                                                                                                                                 
+                       69      82                                                                                                                                                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32    46                                     three.thre  three.three:13  5                     32    46            
- 1                                                                          7     6                                     one.one.on  one:12345 (tcp  1                      7     6            
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 5                                                                         32      46                                   three.thre  three.three:13  5                     32      46          
+ 1                                                                          7       6                                   one.one.on  one:12345 (tcp  1                      7       6          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                three.thre  three.three                                                   32    46            
-                                                                                                one.one.on  one                                                            7     6            
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                three.thre  three.three                                                   32      46          
+                                                                                                one.one.on  one                                                            7       6          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                     91Bps/98Bps                                                                                                                                                              
+                       91Bps / 98Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps/61Bps          <interface_name>:443 => one.one.one.one:12345 (tcp  1                     57Bps/61Bps         
- 5                                                   1                     34Bps/37Bps          <interface_name>:443 => three.three.three.three:13  5                     34Bps/37Bps         
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     57Bps / 61Bps        <interface_name>:443 => one.one.one.one:12345 (tcp  1                     57Bps / 61Bps       
+ 5                                                   1                     34Bps / 37Bps        <interface_name>:443 => three.three.three.three:13  5                     34Bps / 37Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                one.one.one.one                                     1                     57Bps/61Bps         
-                                                                                                three.three.three.three                             1                     34Bps/37Bps         
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                one.one.one.one                                     1                     57Bps / 61Bps       
+                                                                                                three.three.three.three                             1                     34Bps / 37Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                     42Bps/0Bps                                                                                                                                                               
+                       42Bps / 0Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     42Bps/0Bps           <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps/0Bps          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ 1                                                   1                     42Bps / 0Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     42Bps/0Bps          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                1.1.1.1                                             1                     42Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event.snap
@@ -1,10 +1,10 @@
 ---
-source: src/tests/mod.rs
+source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up/Down: 0Bps/0Bps                                                                                                                                                                
+ Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Process                                             Connection count      Rate Up/Down       ││Connection                                          Process               Rate Up/Down       │
+│Process                                             Connection count      Rate Up / Down     ││Connection                                          Process               Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 │                                                                                             │└─────────────────────────────────────────────────────────────────────────────────────────────┘
 │                                                                                             │┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│                                                                                             ││Remote Address                                      Connection Count      Rate Up/Down       │
+│                                                                                             ││Remote Address                                      Connection Count      Rate Up / Down     │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │


### PR DESCRIPTION
This is just an attempt at making bandwidth values more readable. There may be better ways to achieve this, such as color codes.

This kind of tool is all about fast visual grepping, so I figure it's worth trying to find ways to improve readability :slightly_smiling_face:

## Preview

![Bandwidth up/down](https://user-images.githubusercontent.com/180032/71649315-ebac8c00-2d0d-11ea-8772-cfd60580d7e3.png)