### PR TITLE
Display 30 chars for process name

### DIFF
--- a/src/os/lsof_utils.rs
+++ b/src/os/lsof_utils.rs
@@ -22,7 +22,7 @@ lazy_static! {
 impl RawConnection {
     pub fn new(raw_line: &str) -> Option<RawConnection> {
         let raw_connection_iter = CONNECTION_REGEX.captures_iter(raw_line).filter_map(|cap| {
-            let process_name = String::from(cap.get(1).unwrap().as_str());
+            let process_name = String::from(cap.get(1).unwrap().as_str()).replace("\\x20", " ");
             let protocol = String::from(cap.get(2).unwrap().as_str());
             let local_port = String::from(cap.get(3).unwrap().as_str());
             let ip = String::from(cap.get(4).unwrap().as_str());
@@ -62,7 +62,7 @@ impl RawConnection {
 }
 
 pub fn get_connections<'a>() -> RawConnections {
-    let content = run(&["-n", "-P", "-i4"]);
+    let content = run(&["-n", "-P", "-i4", "+c", "0"]);
     RawConnections::new(content)
 }
 


### PR DESCRIPTION
bandwhich uses `lsof` to obtain process names. On MacOS, `lsof` defaults to only showing first 9 characters of process names.

![Xnip2020-01-02_12-30-50](https://user-images.githubusercontent.com/5873227/71681848-d1010400-2d5b-11ea-928a-4976e6905519.jpg)

This is slightly confusing sometimes, for example, in the above screenshot, what is "Google"? I think we should tweek lsof to display more characters. (30 in this commit)

After:

![Xnip2020-01-02_12-31-25](https://user-images.githubusercontent.com/5873227/71681890-f5f57700-2d5b-11ea-817e-eb98dea8b027.jpg)
