### PR TITLE
chore(code): Add error message suggesting sudo if permission error (#59)

### DIFF
--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -41,7 +41,6 @@ fn get_datalink_channel(
         Ok(Ethernet(_tx, rx)) => Ok(rx),
         Ok(_) => failure::bail!("Unknown interface type"),
         Err(e) => {
-            println!("hej");
             match e.kind() {
                 std::io::ErrorKind::PermissionDenied => failure::bail!("Failed to listen on network interface due to permission error. Try running with sudo"),
                 _ => failure::bail!(

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -40,11 +40,17 @@ fn get_datalink_channel(
     match datalink::channel(interface, config) {
         Ok(Ethernet(_tx, rx)) => Ok(rx),
         Ok(_) => failure::bail!("Unknown interface type"),
-        Err(e) => failure::bail!(
-            "Failed to listen on network interface {}: {}",
-            interface.name,
-            e
-        ),
+        Err(e) => {
+            println!("hej");
+            match e.kind() {
+                std::io::ErrorKind::PermissionDenied => failure::bail!("Failed to listen on network interface due to permission error. Try running with sudo"),
+                _ => failure::bail!(
+                    "Failed to listen on network interface {}: {}",
+                    interface.name,
+                    e
+                ),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I decided to use a nested match statement for further handling
of the error, since it appears to be more rustesqe than a
if statement.

This closes #59 

**Note**
I do not appear to need to run with sudo anymore, maybe this is no longer needed?
Tested with tag 0.6.0 (needs sudo) and master branch (does not need sudo)