### PR TITLE
Use the same select timeout for all OSes

### DIFF
--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -34,11 +34,8 @@ fn get_datalink_channel(
     interface: &NetworkInterface,
 ) -> Result<Box<dyn DataLinkReceiver>, failure::Error> {
     let mut config = Config::default();
-    if cfg!(target_os = "macos") {
-        config.read_timeout = Some(time::Duration::new(1, 0));
-    } else {
-        config.read_timeout = Some(time::Duration::new(2, 0));
-    }
+    config.read_timeout = Some(time::Duration::new(1, 0));
+
     match datalink::channel(interface, config) {
         Ok(Ethernet(_tx, rx)) => Ok(rx),
         Ok(_) => failure::bail!("Unknown interface type"),


### PR DESCRIPTION
See [here](https://github.com/imsnif/bandwhich/commit/81ed29ed4091526eeefadec5522229ab882efd92) for the discussion.

The 2s timeout for non-macos OSes was introduced by mistake, but seeing the
improvement on CPU performance it has been decided to trade-off a 1 sec delay
when quitting.

1s seems to make macOS work for now, but we still don't know why the timeout has
any influence on this.