### PR TITLE
fix(error): error when 0 interfaces to listen to are found

### DIFF
--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -106,6 +106,9 @@ pub fn get_input(
         .map(|iface| get_datalink_channel(iface))
         .filter_map(Result::ok)
         .collect::<Vec<_>>();
+    if network_frames.len() == 0 {
+        failure::bail!("Could not find any network interface to listen to. Try running with sudo");
+    }
 
     let keyboard_events = Box::new(KeyboardEvents);
     let write_to_stdout = create_write_to_stdout();

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -108,11 +108,10 @@ pub fn get_input(
     if available_network_frames.is_empty() {
         for iface in network_frames {
             if let Some(iface_error) = iface.err() {
-                match iface_error.kind() {
-                    ErrorKind::PermissionDenied => failure::bail!(
+                if let ErrorKind::PermissionDenied = iface_error.kind() {
+                    failure::bail!(
                         "Insufficient permissions to listen on network interface(s). Try running with sudo.",
-                    ),
-                    _ => ()
+                    )
                 }
             }
         }

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -106,7 +106,7 @@ pub fn get_input(
         .map(|iface| get_datalink_channel(iface))
         .filter_map(Result::ok)
         .collect::<Vec<_>>();
-    if network_frames.len() == 0 {
+    if network_frames.is_empty() {
         failure::bail!("Could not find any network interface to listen to. Try running with sudo");
     }
 


### PR DESCRIPTION
When merging https://github.com/imsnif/bandwhich/pull/49 - I didn't think about the fact that we would get a no-screen-of-death every time we run without sudo, since we're now swallowing those errors.

So while this reduces the verbosity of the error, I think it can do in a pinch. What do you think @ebroto ?