### PR TITLE
Display weighted average of bandwidth

### DIFF
--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -23,8 +23,8 @@ const THIRD_COLUMN_WIDTHS: [u16; 4] = [20, 20, 20, 20];
 fn display_upload_and_download(bandwidth: &impl Bandwidth) -> String {
     format!(
         "{} / {}",
-        DisplayBandwidth(bandwidth.get_avg_bytes_uploaded() as f64),
-        DisplayBandwidth(bandwidth.get_avg_bytes_downloaded() as f64)
+        DisplayBandwidth(bandwidth.get_total_bytes_uploaded() as f64),
+        DisplayBandwidth(bandwidth.get_total_bytes_downloaded() as f64)
     )
 }
 

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -23,8 +23,8 @@ const THIRD_COLUMN_WIDTHS: [u16; 4] = [20, 20, 20, 20];
 fn display_upload_and_download(bandwidth: &impl Bandwidth) -> String {
     format!(
         "{} / {}",
-        DisplayBandwidth(bandwidth.get_total_bytes_uploaded() as f64),
-        DisplayBandwidth(bandwidth.get_total_bytes_downloaded() as f64)
+        DisplayBandwidth(bandwidth.get_avg_bytes_uploaded() as f64),
+        DisplayBandwidth(bandwidth.get_avg_bytes_downloaded() as f64)
     )
 }
 

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -98,7 +98,7 @@ where
         utilization: Utilization,
         ip_to_host: HashMap<Ipv4Addr, String>,
     ) {
-        self.state = UIState::new(connections_to_procs, utilization);
+        self.state = UIState::new(connections_to_procs, utilization, &self.state);
         self.ip_to_host = ip_to_host;
     }
     pub fn end(&mut self) {

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -98,8 +98,8 @@ where
         utilization: Utilization,
         ip_to_host: HashMap<Ipv4Addr, String>,
     ) {
-        self.state = UIState::new(connections_to_procs, utilization, &self.state);
-        self.ip_to_host = ip_to_host;
+        self.state.update(connections_to_procs, utilization);
+        self.ip_to_host.extend(ip_to_host);
     }
     pub fn end(&mut self) {
         self.terminal.clear().unwrap();

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -32,6 +32,15 @@ pub struct ConnectionData {
     pub interface_name: String,
 }
 
+fn calc_avg_bandwidth(prev_bandwidth: u128, curr_bandwidth: u128) -> u128 {
+    if prev_bandwidth == 0 {
+        curr_bandwidth
+    } else {
+        (prev_bandwidth as f32 * BANDWIDTH_DECAY_FACTOR
+            + (1.0 - BANDWIDTH_DECAY_FACTOR) * curr_bandwidth as f32) as u128
+    }
+}
+
 impl Bandwidth for ConnectionData {
     fn get_total_bytes_uploaded(&self) -> u128 {
         self.total_bytes_uploaded
@@ -40,22 +49,13 @@ impl Bandwidth for ConnectionData {
         self.total_bytes_downloaded
     }
     fn get_avg_bytes_uploaded(&self) -> u128 {
-        if self.prev_total_bytes_uploaded == 0 {
-            self.total_bytes_uploaded
-        } else {
-            (self.prev_total_bytes_uploaded as f32 * BANDWIDTH_DECAY_FACTOR
-                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_uploaded as f32)
-                as u128
-        }
+        calc_avg_bandwidth(self.prev_total_bytes_uploaded, self.total_bytes_uploaded)
     }
     fn get_avg_bytes_downloaded(&self) -> u128 {
-        if self.prev_total_bytes_downloaded == 0 {
-            self.total_bytes_downloaded
-        } else {
-            (self.prev_total_bytes_downloaded as f32 * BANDWIDTH_DECAY_FACTOR
-                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_downloaded as f32)
-                as u128
-        }
+        calc_avg_bandwidth(
+            self.prev_total_bytes_downloaded,
+            self.total_bytes_downloaded,
+        )
     }
 }
 
@@ -67,22 +67,13 @@ impl Bandwidth for NetworkData {
         self.total_bytes_downloaded
     }
     fn get_avg_bytes_uploaded(&self) -> u128 {
-        if self.prev_total_bytes_uploaded == 0 {
-            self.total_bytes_uploaded
-        } else {
-            (self.prev_total_bytes_uploaded as f32 * BANDWIDTH_DECAY_FACTOR
-                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_uploaded as f32)
-                as u128
-        }
+        calc_avg_bandwidth(self.prev_total_bytes_uploaded, self.total_bytes_uploaded)
     }
     fn get_avg_bytes_downloaded(&self) -> u128 {
-        if self.prev_total_bytes_downloaded == 0 {
-            self.total_bytes_downloaded
-        } else {
-            (self.prev_total_bytes_downloaded as f32 * BANDWIDTH_DECAY_FACTOR
-                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_downloaded as f32)
-                as u128
-        }
+        calc_avg_bandwidth(
+            self.prev_total_bytes_downloaded,
+            self.total_bytes_downloaded,
+        )
     }
 }
 

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -3,15 +3,22 @@ use ::std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::network::{Connection, LocalSocket, Utilization};
 
+static BANDWIDTH_DECAY_FACTOR: f32 = 0.5;
+
 pub trait Bandwidth {
     fn get_total_bytes_downloaded(&self) -> u128;
     fn get_total_bytes_uploaded(&self) -> u128;
+
+    fn get_avg_bytes_downloaded(&self) -> u128;
+    fn get_avg_bytes_uploaded(&self) -> u128;
 }
 
 #[derive(Default)]
 pub struct NetworkData {
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
+    pub prev_total_bytes_downloaded: u128,
+    pub prev_total_bytes_uploaded: u128,
     pub connection_count: u128,
 }
 
@@ -19,6 +26,8 @@ pub struct NetworkData {
 pub struct ConnectionData {
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
+    pub prev_total_bytes_downloaded: u128,
+    pub prev_total_bytes_uploaded: u128,
     pub process_name: String,
     pub interface_name: String,
 }
@@ -30,6 +39,24 @@ impl Bandwidth for ConnectionData {
     fn get_total_bytes_downloaded(&self) -> u128 {
         self.total_bytes_downloaded
     }
+    fn get_avg_bytes_uploaded(&self) -> u128 {
+        if self.prev_total_bytes_uploaded == 0 {
+            self.total_bytes_uploaded
+        } else {
+            (self.prev_total_bytes_uploaded as f32 * BANDWIDTH_DECAY_FACTOR
+                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_uploaded as f32)
+                as u128
+        }
+    }
+    fn get_avg_bytes_downloaded(&self) -> u128 {
+        if self.prev_total_bytes_downloaded == 0 {
+            self.total_bytes_downloaded
+        } else {
+            (self.prev_total_bytes_downloaded as f32 * BANDWIDTH_DECAY_FACTOR
+                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_downloaded as f32)
+                as u128
+        }
+    }
 }
 
 impl Bandwidth for NetworkData {
@@ -38,6 +65,24 @@ impl Bandwidth for NetworkData {
     }
     fn get_total_bytes_downloaded(&self) -> u128 {
         self.total_bytes_downloaded
+    }
+    fn get_avg_bytes_uploaded(&self) -> u128 {
+        if self.prev_total_bytes_uploaded == 0 {
+            self.total_bytes_uploaded
+        } else {
+            (self.prev_total_bytes_uploaded as f32 * BANDWIDTH_DECAY_FACTOR
+                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_uploaded as f32)
+                as u128
+        }
+    }
+    fn get_avg_bytes_downloaded(&self) -> u128 {
+        if self.prev_total_bytes_downloaded == 0 {
+            self.total_bytes_downloaded
+        } else {
+            (self.prev_total_bytes_downloaded as f32 * BANDWIDTH_DECAY_FACTOR
+                + (1.0 - BANDWIDTH_DECAY_FACTOR) * self.total_bytes_downloaded as f32)
+                as u128
+        }
     }
 }
 
@@ -74,6 +119,7 @@ impl UIState {
     pub fn new(
         connections_to_procs: HashMap<LocalSocket, String>,
         network_utilization: Utilization,
+        old_state: &UIState,
     ) -> Self {
         let mut processes: BTreeMap<String, NetworkData> = BTreeMap::new();
         let mut remote_addresses: BTreeMap<Ipv4Addr, NetworkData> = BTreeMap::new();
@@ -82,18 +128,6 @@ impl UIState {
         let mut total_bytes_uploaded: u128 = 0;
         for (connection, connection_info) in network_utilization.connections {
             let connection_data = connections.entry(connection).or_default();
-
-            if let Some(process_name) =
-                UIState::get_proc_name(&connections_to_procs, &connection.local_socket)
-            {
-                let data_for_process = processes.entry(process_name.clone()).or_default();
-                data_for_process.total_bytes_downloaded += connection_info.total_bytes_downloaded;
-                data_for_process.total_bytes_uploaded += connection_info.total_bytes_uploaded;
-                data_for_process.connection_count += 1;
-                connection_data.process_name = process_name.clone();
-            } else {
-                connection_data.process_name = String::from("<UNKNOWN>");
-            }
             let data_for_remote_address = remote_addresses
                 .entry(connection.remote_socket.ip)
                 .or_default();
@@ -106,6 +140,33 @@ impl UIState {
             data_for_remote_address.connection_count += 1;
             total_bytes_downloaded += connection_info.total_bytes_downloaded;
             total_bytes_uploaded += connection_info.total_bytes_uploaded;
+
+            if let Some(process_name) =
+                UIState::get_proc_name(&connections_to_procs, &connection.local_socket)
+            {
+                let data_for_process = processes.entry(process_name.clone()).or_default();
+                data_for_process.total_bytes_downloaded += connection_info.total_bytes_downloaded;
+                data_for_process.total_bytes_uploaded += connection_info.total_bytes_uploaded;
+                data_for_process.connection_count += 1;
+                connection_data.process_name = process_name.clone();
+                // Record bandwidth data of last iteration
+                if let Some(prev_connection_info) = old_state.connections.get(&connection) {
+                    // Using previous round's weighted average. Exponential decay
+                    let prev_bytes_downloaded = prev_connection_info.get_avg_bytes_downloaded();
+                    let prev_bytes_uploaded = prev_connection_info.get_avg_bytes_uploaded();
+    
+                    connection_data.prev_total_bytes_downloaded += prev_bytes_downloaded;
+                    connection_data.prev_total_bytes_uploaded += prev_bytes_uploaded;
+    
+                    data_for_process.prev_total_bytes_downloaded += prev_bytes_downloaded;
+                    data_for_process.prev_total_bytes_uploaded += prev_bytes_uploaded;
+    
+                    data_for_remote_address.prev_total_bytes_downloaded += prev_bytes_downloaded;
+                    data_for_remote_address.prev_total_bytes_uploaded += prev_bytes_uploaded;
+                }
+            } else {
+                connection_data.process_name = String::from("<UNKNOWN>");
+            }
         }
         UIState {
             processes,

--- a/src/tests/cases/snapshots/raw_mode__bi_directional_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__bi_directional_traffic.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 49/51 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 49/51 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 49/51 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 24/25 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 24/25 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 24/25 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
@@ -2,8 +2,8 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/95 connections: 2
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/51 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/95 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/47 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/25 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/47 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_different_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_different_connections.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
-process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/39 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 2.2.2.2:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/39 process: "4"
-remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/83 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
+process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/19 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 2.2.2.2:12345 (tcp) up/down Bps: 0/22 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/19 process: "4"
+remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/41 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_single_connection.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_single_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/91 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/91 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/91 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/45 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/45 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/45 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
-process: <TIMESTAMP_REMOVED> "2" up/down Bps: 0/42 connections: 1
-process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/53 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/45 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/53 process: "4"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/45 process: "5"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4432 => 4.4.4.4:1337 (tcp) up/down Bps: 0/42 process: "2"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/53 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/45 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 4.4.4.4 up/down Bps: 0/42 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
+process: <TIMESTAMP_REMOVED> "2" up/down Bps: 0/21 connections: 1
+process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/26 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/22 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/26 process: "4"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/22 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4432 => 4.4.4.4:1337 (tcp) up/down Bps: 0/21 process: "2"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/26 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/22 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 4.4.4.4 up/down Bps: 0/21 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 57/61 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 34/37 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 57/61 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 34/37 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 57/61 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 34/37 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 37/36 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 32/46 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 37/36 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 32/46 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 37/36 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 32/46 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 28/30 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 17/18 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 28/30 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 17/18 process: "5"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 28/30 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 17/18 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 2
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 31/32 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 22/27 process: "5"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__one_ip_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_ip_packet_of_traffic.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 42/0 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 42/0 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 42/0 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 21/0 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 21/0 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 21/0 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__one_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_packet_of_traffic.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 42/0 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 42/0 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 42/0 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 21/0 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 21/0 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 21/0 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
@@ -2,8 +2,8 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/92 connections: 2
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/48 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/92 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/46 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/24 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/46 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/39 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/39 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/39 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/61 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/51 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/61 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/51 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/61 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/51 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/19 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/19 process: "5"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/19 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/35 connections: 2
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/30 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/35 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/30 process: "5"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/35 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/30 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 57/61 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 34/37 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 57/61 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 34/37 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 57/61 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 34/37 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 37/36 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 32/46 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 37/36 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 32/46 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 37/36 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 32/46 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 28/30 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 17/18 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 28/30 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 17/18 process: "5"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 28/30 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 17/18 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 2
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 31/32 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 22/27 process: "5"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
@@ -2,10 +2,10 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/44 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/44 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/44 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/51 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/51 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/51 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/31 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/31 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/31 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 57/61 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 34/37 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 57/61 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 34/37 process: "5"
-remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 57/61 connections: 1
-remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 34/37 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 37/36 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 32/46 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 37/36 process: "1"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 32/46 process: "5"
-remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 37/36 connections: 1
-remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 32/46 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 28/30 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 17/18 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 28/30 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 17/18 process: "5"
+remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 28/30 connections: 1
+remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 17/18 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 2
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 2
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 31/32 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 22/27 process: "5"
+remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 31/32 connections: 2
+remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 22/27 connections: 2
 

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     49Bps / 51Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     49Bps / 51Bps       
+ 1                                                   1                     24Bps / 25Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     24Bps / 25Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     49Bps / 51Bps       
+                                                                                                1.1.1.1                                             1                     24Bps / 25Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 4                                                   1                     0Bps / 53Bps         <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 53Bps        
- 5                                                   1                     0Bps / 45Bps         <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 45Bps        
- 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
- 2                                                   1                     0Bps / 42Bps         <interface_name>:4432 => 4.4.4.4:1337 (tcp)         2                     0Bps / 42Bps        
+ 4                                                   1                     0Bps / 26Bps         <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 26Bps        
+ 1                                                   1                     0Bps / 22Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps        
+ 5                                                   1                     0Bps / 22Bps         <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 22Bps        
+ 2                                                   1                     0Bps / 21Bps         <interface_name>:4432 => 4.4.4.4:1337 (tcp)         2                     0Bps / 21Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                        
                                                                                                                        
                                                                                                                        
- 4                                                   1                     0Bps / 53Bps                                
- 5                                                   1                     0Bps / 45Bps                                
- 1                                                   1                     0Bps / 44Bps                                
- 2                                                   1                     0Bps / 42Bps                                
+ 4                                                   1                     0Bps / 26Bps                                
+ 1                                                   1                     0Bps / 22Bps                                
+ 5                                                   1                     0Bps / 22Bps                                
+ 2                                                   1                     0Bps / 21Bps                                
                                                                                                                        
                                                                                                                        
                                                                                                                        
@@ -30,10 +30,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                        
                                                                                                                        
                                                                                                                        
- <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 53Bps                                
- <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 45Bps                                
- <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps                                
- <interface_name>:4432 => 4.4.4.4:1337 (tcp)         2                     0Bps / 42Bps                                
+ <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 26Bps                                
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps                                
+ <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 22Bps                                
+ <interface_name>:4432 => 4.4.4.4:1337 (tcp)         2                     0Bps / 21Bps                                
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                        
                                                                                                                        
                                                                                                                        
- 4                                                   1                     0Bps / 53Bps                                
- 5                                                   1                     0Bps / 45Bps                                
- 1                                                   1                     0Bps / 44Bps                                
- 2                                                   1                     0Bps / 42Bps                                
+ 4                                                   1                     0Bps / 26Bps                                
+ 1                                                   1                     0Bps / 22Bps                                
+ 5                                                   1                     0Bps / 22Bps                                
+ 2                                                   1                     0Bps / 21Bps                                
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- 4                                                   1                     0Bps / 53Bps                                                              
- 5                                                   1                     0Bps / 45Bps                                                              
- 1                                                   1                     0Bps / 44Bps                                                              
- 2                                                   1                     0Bps / 42Bps                                                              
+ 4                                                   1                     0Bps / 26Bps                                                              
+ 1                                                   1                     0Bps / 22Bps                                                              
+ 5                                                   1                     0Bps / 22Bps                                                              
+ 2                                                   1                     0Bps / 21Bps                                                              
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
@@ -30,10 +30,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- <interface_name>:4434 => 2.2.2.2:54321 (  0Bps / 53Bps                    2.2.2.2                                   0Bps / 53Bps                    
- <interface_name>:4435 => 3.3.3.3:1337 (t  0Bps / 45Bps                    3.3.3.3                                   0Bps / 45Bps                    
- <interface_name>:443 => 1.1.1.1:12345 (t  0Bps / 44Bps                    1.1.1.1                                   0Bps / 44Bps                    
- <interface_name>:4432 => 4.4.4.4:1337 (t  0Bps / 42Bps                    4.4.4.4                                   0Bps / 42Bps                    
+ <interface_name>:4434 => 2.2.2.2:54321 (  0Bps / 26Bps                    2.2.2.2                                   0Bps / 26Bps                    
+ <interface_name>:443 => 1.1.1.1:12345 (t  0Bps / 22Bps                    1.1.1.1                                   0Bps / 22Bps                    
+ <interface_name>:4435 => 3.3.3.3:1337 (t  0Bps / 22Bps                    3.3.3.3                                   0Bps / 22Bps                    
+ <interface_name>:4432 => 4.4.4.4:1337 (t  0Bps / 21Bps                    4.4.4.4                                   0Bps / 21Bps                    
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      
- 4                                         0Bps / 53Bps                    <interface_name>:4434 => 2.2.2.2:54321 (  0Bps / 53Bps                    
- 5                                         0Bps / 45Bps                    <interface_name>:4435 => 3.3.3.3:1337 (t  0Bps / 45Bps                    
- 1                                         0Bps / 44Bps                    <interface_name>:443 => 1.1.1.1:12345 (t  0Bps / 44Bps                    
- 2                                         0Bps / 42Bps                    <interface_name>:4432 => 4.4.4.4:1337 (t  0Bps / 42Bps                    
+ 4                                         0Bps / 26Bps                    <interface_name>:4434 => 2.2.2.2:54321 (  0Bps / 26Bps                    
+ 1                                         0Bps / 22Bps                    <interface_name>:443 => 1.1.1.1:12345 (t  0Bps / 22Bps                    
+ 5                                         0Bps / 22Bps                    <interface_name>:4435 => 3.3.3.3:1337 (t  0Bps / 22Bps                    
+ 2                                         0Bps / 21Bps                    <interface_name>:4432 => 4.4.4.4:1337 (t  0Bps / 21Bps                    
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   2                     0Bps / 95Bps         <interface_name>:443 => 1.1.1.1:12346 (tcp)         1                     0Bps / 51Bps        
-                                                                                                <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 1                                                   2                     0Bps / 47Bps         <interface_name>:443 => 1.1.1.1:12346 (tcp)         1                     0Bps / 25Bps        
+                                                                                                <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             2                     0Bps / 95Bps        
+                                                                                                1.1.1.1                                             2                     0Bps / 47Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 2.2.2.2:12345 (tcp)         1                     0Bps / 44Bps        
- 4                                                   1                     0Bps / 39Bps         <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 39Bps        
+ 1                                                   1                     0Bps / 22Bps         <interface_name>:443 => 2.2.2.2:12345 (tcp)         1                     0Bps / 22Bps        
+ 4                                                   1                     0Bps / 19Bps         <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 19Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                2.2.2.2                                             2                     0Bps / 83Bps        
+                                                                                                2.2.2.2                                             2                     0Bps / 41Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps / 91Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 91Bps        
+ 1                                                   1                     0Bps / 45Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 45Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps / 91Bps        
+                                                                                                1.1.1.1                                             1                     0Bps / 45Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
@@ -6,10 +6,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 4                                                   1                     0Bps / 53Bps         <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 53Bps        
- 5                                                   1                     0Bps / 45Bps         <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 45Bps        
- 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
- 2                                                   1                     0Bps / 42Bps         <interface_name>:4432 => 4.4.4.4:1337 (tcp)         2                     0Bps / 42Bps        
+ 4                                                   1                     0Bps / 26Bps         <interface_name>:4434 => 2.2.2.2:54321 (tcp)        4                     0Bps / 26Bps        
+ 1                                                   1                     0Bps / 22Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps        
+ 5                                                   1                     0Bps / 22Bps         <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 22Bps        
+ 2                                                   1                     0Bps / 21Bps         <interface_name>:4432 => 4.4.4.4:1337 (tcp)         2                     0Bps / 21Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,10 +30,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                2.2.2.2                                             1                     0Bps / 53Bps        
-                                                                                                3.3.3.3                                             1                     0Bps / 45Bps        
-                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
-                                                                                                4.4.4.4                                             1                     0Bps / 42Bps        
+                                                                                                2.2.2.2                                             1                     0Bps / 26Bps        
+                                                                                                1.1.1.1                                             1                     0Bps / 22Bps        
+                                                                                                3.3.3.3                                             1                     0Bps / 22Bps        
+                                                                                                4.4.4.4                                             1                     0Bps / 21Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
@@ -30,8 +30,13 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+<<<<<<< HEAD
                                                                                                 3 3 3 3                                                                   32      46          
                                                                                                 1 1 1 1                                                                    7       6          
+=======
+                                                                                                3 3 3 3                                                                   33    4             
+                                                                                                1 1 1 1                                                                   47    48            
+>>>>>>> Update UI snapshots for new bandwidth calculation
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       69      82                                                                                                                                                             
+                       160Bps / 180Bps                                                                                                                                                        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32      46                               5 => 3.3.3.3:1 37               5                     32      46          
- 1                                                                          7       6                                => 1.1.1.1:12 45               1                      7       6          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                     2                     31       2                                                                                     31       2          
+                                                     2                     22      27                                                                                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,13 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-<<<<<<< HEAD
-                                                                                                3 3 3 3                                                                   32      46          
-                                                                                                1 1 1 1                                                                    7       6          
-=======
-                                                                                                3 3 3 3                                                                   33    4             
-                                                                                                1 1 1 1                                                                   47    48            
->>>>>>> Update UI snapshots for new bandwidth calculation
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                    2                     31       2          
+                                                                                                                                                    2                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps / 61Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps / 61Bps       
- 5                                                   1                     34Bps / 37Bps        <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     34Bps / 37Bps       
+ 1                                                   1                     28Bps / 30Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     28Bps / 30Bps       
+ 5                                                   1                     17Bps / 18Bps        <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     17Bps / 18Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +30,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     57Bps / 61Bps       
-                                                                                                3.3.3.3                                             1                     34Bps / 37Bps       
+                                                                                                1.1.1.1                                             1                     28Bps / 30Bps       
+                                                                                                3.3.3.3                                             1                     17Bps / 18Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     42Bps / 0Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps / 0Bps        
+ 1                                                   1                     21Bps / 0Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     21Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     42Bps / 0Bps        
+                                                                                                1.1.1.1                                             1                     21Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   2                     0Bps / 92Bps         <interface_name>:443 => 1.1.1.1:12346 (tcp)         1                     0Bps / 48Bps        
-                                                                                                <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 1                                                   2                     0Bps / 46Bps         <interface_name>:443 => 1.1.1.1:12346 (tcp)         1                     0Bps / 24Bps        
+                                                                                                <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             2                     0Bps / 92Bps        
+                                                                                                1.1.1.1                                             2                     0Bps / 46Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
@@ -30,8 +30,13 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+<<<<<<< HEAD
                                                                                                                                                                                  61           
                                                                                                                                                                                  51           
+=======
+                                                                                                                                                                               52             
+                                                                                                                                                                               45             
+>>>>>>> Update UI snapshots for new bandwidth calculation
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                              112Bps                                                                                                                                                          
+                              195Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                  61                                                                                             61           
-                                                                                  51                                                                                             51           
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                     2                            35                                                                                             35           
+                                                     2                            30                                                                                             30           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,13 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-<<<<<<< HEAD
-                                                                                                                                                                                 61           
-                                                                                                                                                                                 51           
-=======
-                                                                                                                                                                               52             
-                                                                                                                                                                               45             
->>>>>>> Update UI snapshots for new bandwidth calculation
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                    2                            35           
+                                                                                                                                                    2                            30           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
- 5                                                   1                     0Bps / 39Bps         <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 39Bps        
+ 1                                                   1                     0Bps / 22Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps        
+ 5                                                   1                     0Bps / 19Bps         <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     0Bps / 19Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +30,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
-                                                                                                3.3.3.3                                             1                     0Bps / 39Bps        
+                                                                                                1.1.1.1                                             1                     0Bps / 22Bps        
+                                                                                                3.3.3.3                                             1                     0Bps / 19Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
@@ -30,8 +30,13 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+<<<<<<< HEAD
                                                                                                 3 3 3 3                                                                   32      46          
                                                                                                 1 1 1 1                                                                    7       6          
+=======
+                                                                                                3 3 3 3                                                                   33    4             
+                                                                                                1 1 1 1                                                                   47    48            
+>>>>>>> Update UI snapshots for new bandwidth calculation
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       69      82                                                                                                                                                             
+                       160Bps / 180Bps                                                                                                                                                        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32      46                               5 => 3.3.3.3:1 37               5                     32      46          
- 1                                                                          7       6                                => 1.1.1.1:12 45               1                      7       6          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                     2                     31       2                                                                                     31       2          
+                                                     2                     22      27                                                                                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,13 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-<<<<<<< HEAD
-                                                                                                3 3 3 3                                                                   32      46          
-                                                                                                1 1 1 1                                                                    7       6          
-=======
-                                                                                                3 3 3 3                                                                   33    4             
-                                                                                                1 1 1 1                                                                   47    48            
->>>>>>> Update UI snapshots for new bandwidth calculation
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                    2                     31       2          
+                                                                                                                                                    2                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps / 61Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     57Bps / 61Bps       
- 5                                                   1                     34Bps / 37Bps        <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     34Bps / 37Bps       
+ 1                                                   1                     28Bps / 30Bps        <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     28Bps / 30Bps       
+ 5                                                   1                     17Bps / 18Bps        <interface_name>:4435 => 3.3.3.3:1337 (tcp)         5                     17Bps / 18Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +30,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     57Bps / 61Bps       
-                                                                                                3.3.3.3                                             1                     34Bps / 37Bps       
+                                                                                                1.1.1.1                                             1                     28Bps / 30Bps       
+                                                                                                3.3.3.3                                             1                     17Bps / 18Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
@@ -30,7 +30,11 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+<<<<<<< HEAD
                                                                                                                                                                                  51           
+=======
+                                                                                                                                                                                7             
+>>>>>>> Update UI snapshots for new bandwidth calculation
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                              51                                                                                                                                                              
+                              95                                                                                                                                                              
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                  51                                                                                             51           
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                     2                            31                                                                                             31           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,11 +26,11 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-<<<<<<< HEAD
-                                                                                                                                                                                 51           
-=======
-                                                                                                                                                                                7             
->>>>>>> Update UI snapshots for new bandwidth calculation
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                    2                            31           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     0Bps / 44Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 44Bps        
+ 1                                                   1                     0Bps / 22Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     0Bps / 22Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     0Bps / 44Bps        
+                                                                                                1.1.1.1                                             1                     0Bps / 22Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
@@ -30,8 +30,13 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+<<<<<<< HEAD
                                                                                                 three.thre  three.three                                                   32      46          
                                                                                                 one.one.on  one                                                            7       6          
+=======
+                                                                                                three.thre  three.three                                                   33    4             
+                                                                                                one.one.on  one                                                           47    48            
+>>>>>>> Update UI snapshots for new bandwidth calculation
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       69      82                                                                                                                                                             
+                       160Bps / 180Bps                                                                                                                                                        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 5                                                                         32      46                               5 => three.thr e.three.three:1  5                     32      46          
- 1                                                                          7       6                                => one.one.on .one:12345 (tcp  1                      7       6          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                     2                     31       2                                                                                     31       2          
+                                                     2                     22      27                                                                                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,13 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-<<<<<<< HEAD
-                                                                                                three.thre  three.three                                                   32      46          
-                                                                                                one.one.on  one                                                            7       6          
-=======
-                                                                                                three.thre  three.three                                                   33    4             
-                                                                                                one.one.on  one                                                           47    48            
->>>>>>> Update UI snapshots for new bandwidth calculation
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                    2                     31       2          
+                                                                                                                                                    2                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
@@ -6,8 +6,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     57Bps / 61Bps        <interface_name>:443 => one.one.one.one:12345 (tcp  1                     57Bps / 61Bps       
- 5                                                   1                     34Bps / 37Bps        <interface_name>:4435 => three.three.three.three:1  5                     34Bps / 37Bps       
+ 1                                                   1                     28Bps / 30Bps        <interface_name>:443 => one.one.one.one:12345 (tcp  1                     28Bps / 30Bps       
+ 5                                                   1                     17Bps / 18Bps        <interface_name>:4435 => three.three.three.three:1  5                     17Bps / 18Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +30,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                one.one.one.one                                     1                     57Bps / 61Bps       
-                                                                                                three.three.three.three                             1                     34Bps / 37Bps       
+                                                                                                one.one.one.one                                     1                     28Bps / 30Bps       
+                                                                                                three.three.three.three                             1                     17Bps / 18Bps       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
@@ -6,7 +6,7 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- 1                                                   1                     42Bps / 0Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     42Bps / 0Bps        
+ 1                                                   1                     21Bps / 0Bps         <interface_name>:443 => 1.1.1.1:12345 (tcp)         1                     21Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +30,7 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                1.1.1.1                                             1                     42Bps / 0Bps        
+                                                                                                1.1.1.1                                             1                     21Bps / 0Bps        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               


### PR DESCRIPTION
The idea of exponential decay is used. When displaying bandwidth, it takes an weighted average of all bandwidth in the past. The bandwidth of last 1 second gets weight `0.5`, the bandwidth of last 2 seconds gets weight `0.25`, etc.

This change should smoothen the be bandwidth curve somewhat, while giving recent bandwidth data more weight.