### PR TITLE
Fix UTF8 decoding error on some non UTF8 system

### DIFF
--- a/src/os/lsof_utils.rs
+++ b/src/os/lsof_utils.rs
@@ -76,7 +76,7 @@ where
         .output()
         .expect("failed to execute process");
 
-    String::from_utf8(output.stdout).unwrap()
+    String::from_utf8_lossy(&output.stdout).into_owned()
 }
 
 pub struct RawConnections {


### PR DESCRIPTION
In response to issue #50 

`from_utf8_lossy` will always succeed, it converts bytes to UTF8 string, escaping/discarding invalid bytes