### PR TITLE
fix Mac build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "packet-builder 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "procfs 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -854,25 +853,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pnet_bandwhich_fork"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "pnet_base"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "pnet_base_bandwhich_fork"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -885,18 +866,6 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_datalink_bandwhich_fork"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -932,16 +901,6 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pnet_sys_bandwhich_fork"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1922,16 +1881,12 @@ dependencies = [
 "checksum pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cf9ef46222a90a9d1e35bb4fa208e1076c6663a02d8ecf3e264fd5001ab6e8e"
-"checksum pnet_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a72aace99497b045096dc467f55e819baccb60192caedb45619cdbe65bca4ea"
 "checksum pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d818b94d0897cd22f7a18f6c2a94f7ae1dfcedc194bf1665880f6c1155e051"
-"checksum pnet_base_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0886cdc1878c06687cbee7d3ed5045380e57b164bf69f036570559c07f6de88"
 "checksum pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "557ff7deb5ad2b35ac17a495d629d64dfeacf02e7f4834974dceb5e2cc544d55"
-"checksum pnet_datalink_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf8691094ddce0573d0677a30860caddc533692dfc93570d03e737a76b579d50"
 "checksum pnet_macros 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d228096fd739d4e3e60dee9e1e4f07d9ae0f3f309c876834192538748e561e4"
 "checksum pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6158bbc3627b9ce01526f5ff8b9895224a0dc96c27baaf79cda0f703a4898ea"
 "checksum pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7efa93f5572ed735852737232ba7539977799861642aaba05de87b6a03dc0f74"
 "checksum pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab2f8311f738773513fc8192a77e8f77461d97333184c23597a23cb9eb0bd0eb"
-"checksum pnet_sys_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "019c5cdc431afe23ae950d145cdf6cc321a8ef4ece501a4cb92c79c3ed4cdabf"
 "checksum pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40851df523364df420e1c85e4885319656904a189a9352657ececcb3c2314fc0"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,14 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -90,8 +82,8 @@ dependencies = [
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "packet-builder 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
  "procfs 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -755,8 +747,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
  "pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -842,20 +834,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "pnet"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
 dependencies = [
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_datalink 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_packet 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_sys 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_transport 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
 ]
 
 [[package]]
 name = "pnet_base"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
+
+[[package]]
+name = "pnet_datalink"
+version = "0.23.0"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
+dependencies = [
+ "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_sys 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pnet_datalink"
@@ -864,17 +868,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
  "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pnet_macros"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.23.0"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
 dependencies = [
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -882,21 +886,39 @@ dependencies = [
 [[package]]
 name = "pnet_macros_support"
 version = "0.23.0"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
+dependencies = [
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
 ]
 
 [[package]]
 name = "pnet_packet"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_macros 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_macros_support 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
  "syntex 0.42.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.23.0"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -912,12 +934,12 @@ dependencies = [
 [[package]]
 name = "pnet_transport"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich#178d4c14d08e8e60877107a83a93c5154b95b070"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_packet 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
+ "pnet_sys 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)",
 ]
 
 [[package]]
@@ -1157,18 +1179,6 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1176,14 +1186,6 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1608,11 +1610,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ucd-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,11 +1659,6 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
@@ -1783,7 +1775,6 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
-"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f1a1eca3195b729bbd64e292ef2f5fff6b1c28504fed762ce2b1013dde4d8e92"
@@ -1880,14 +1871,17 @@ dependencies = [
 "checksum pest_meta 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "df43fd99896fd72c485fe47542c7b500e4ac1e8700bf995544d1317a60ded547"
 "checksum pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
-"checksum pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cf9ef46222a90a9d1e35bb4fa208e1076c6663a02d8ecf3e264fd5001ab6e8e"
-"checksum pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d818b94d0897cd22f7a18f6c2a94f7ae1dfcedc194bf1665880f6c1155e051"
+"checksum pnet 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
+"checksum pnet_base 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
+"checksum pnet_datalink 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
 "checksum pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "557ff7deb5ad2b35ac17a495d629d64dfeacf02e7f4834974dceb5e2cc544d55"
-"checksum pnet_macros 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d228096fd739d4e3e60dee9e1e4f07d9ae0f3f309c876834192538748e561e4"
+"checksum pnet_macros 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
+"checksum pnet_macros_support 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
 "checksum pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6158bbc3627b9ce01526f5ff8b9895224a0dc96c27baaf79cda0f703a4898ea"
-"checksum pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7efa93f5572ed735852737232ba7539977799861642aaba05de87b6a03dc0f74"
+"checksum pnet_packet 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
+"checksum pnet_sys 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
 "checksum pnet_sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab2f8311f738773513fc8192a77e8f77461d97333184c23597a23cb9eb0bd0eb"
-"checksum pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40851df523364df420e1c85e4885319656904a189a9352657ececcb3c2314fc0"
+"checksum pnet_transport 0.23.0 (git+https://github.com/zhangxp1998/libpnet.git?branch=bandwhich)" = "<none>"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
@@ -1915,9 +1909,7 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
-"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
@@ -1965,7 +1957,6 @@ dependencies = [
 "checksum tui 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ff64c925f5e20d7a393c598a33b6afc9c9942e7ebc530085588f5b7667ea559"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
-"checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
@@ -1974,7 +1965,6 @@ dependencies = [
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
-"checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ pnet_base = "0.23.0"
 cargo-insta = "0.11.0"
 packet-builder = "0.4.0"
 regex = "1"
+
+[patch.crates-io]
+pnet = { git = "https://github.com/zhangxp1998/libpnet.git", branch = 'bandwhich'}
+pnet_base = { git = "https://github.com/zhangxp1998/libpnet.git", branch = 'bandwhich'}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 exclude = ["src/tests/*", "demo.gif"]
 
 [dependencies]
-pnet_bandwhich_fork = "0.23.0"
+pnet = "0.23.0"
 ipnetwork = "0.15.0"
 tui = "0.5"
 termion = "1.5"
@@ -36,7 +36,6 @@ procfs = "0.7.4"
 
 [dev-dependencies]
 insta = "0.12.0"
-pnet = "0.23.0"
 pnet_base = "0.23.0"
 cargo-insta = "0.11.0"
 packet-builder = "0.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use network::{
 };
 use os::OnSigWinch;
 
-use ::pnet_bandwhich_fork::datalink::{DataLinkReceiver, NetworkInterface};
+use ::pnet::datalink::{DataLinkReceiver, NetworkInterface};
 use ::std::collections::HashMap;
 use ::std::sync::atomic::{AtomicBool, Ordering};
 use ::std::sync::{Arc, Mutex};

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -1,12 +1,12 @@
 use ::std::boxed::Box;
 
-use ::pnet_bandwhich_fork::datalink::{DataLinkReceiver, NetworkInterface};
-use ::pnet_bandwhich_fork::packet::ethernet::{EtherType, EthernetPacket};
-use ::pnet_bandwhich_fork::packet::ip::IpNextHeaderProtocol;
-use ::pnet_bandwhich_fork::packet::ipv4::Ipv4Packet;
-use ::pnet_bandwhich_fork::packet::tcp::TcpPacket;
-use ::pnet_bandwhich_fork::packet::udp::UdpPacket;
-use ::pnet_bandwhich_fork::packet::Packet;
+use ::pnet::datalink::{DataLinkReceiver, NetworkInterface};
+use ::pnet::packet::ethernet::{EtherType, EthernetPacket};
+use ::pnet::packet::ip::IpNextHeaderProtocol;
+use ::pnet::packet::ipv4::Ipv4Packet;
+use ::pnet::packet::tcp::TcpPacket;
+use ::pnet::packet::udp::UdpPacket;
+use ::pnet::packet::Packet;
 
 use ::ipnetwork::IpNetwork;
 use ::std::net::{IpAddr, SocketAddr};

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -1,6 +1,6 @@
-use ::pnet_bandwhich_fork::datalink::Channel::Ethernet;
-use ::pnet_bandwhich_fork::datalink::DataLinkReceiver;
-use ::pnet_bandwhich_fork::datalink::{self, Config, NetworkInterface};
+use ::pnet::datalink::Channel::Ethernet;
+use ::pnet::datalink::DataLinkReceiver;
+use ::pnet::datalink::{self, Config, NetworkInterface};
 use ::std::io::{self, stdin, Write};
 use ::termion::event::Event;
 use ::termion::input::TermRead;

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -8,8 +8,8 @@ use ::std::net::IpAddr;
 
 use packet_builder::payload::PayloadData;
 use packet_builder::*;
-use pnet_bandwhich_fork::datalink::DataLinkReceiver;
-use pnet_bandwhich_fork::packet::Packet;
+use pnet::datalink::DataLinkReceiver;
+use pnet::packet::Packet;
 use pnet_base::MacAddr;
 
 use crate::tests::cases::test_utils::{

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -7,7 +7,7 @@ use std::iter;
 use crate::network::dns::Client;
 use crate::{Opt, OsInputOutput};
 use ::termion::event::{Event, Key};
-use pnet_bandwhich_fork::datalink::DataLinkReceiver;
+use pnet::datalink::DataLinkReceiver;
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::{Arc, Mutex};

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -13,8 +13,8 @@ use crate::tests::cases::test_utils::{
 };
 use packet_builder::payload::PayloadData;
 use packet_builder::*;
-use pnet_bandwhich_fork::datalink::DataLinkReceiver;
-use pnet_bandwhich_fork::packet::Packet;
+use pnet::datalink::DataLinkReceiver;
+use pnet::packet::Packet;
 use pnet_base::MacAddr;
 
 use crate::{start, Opt, OsInputOutput};

--- a/src/tests/fakes/fake_input.rs
+++ b/src/tests/fakes/fake_input.rs
@@ -1,7 +1,7 @@
 use ::async_trait::async_trait;
 use ::ipnetwork::IpNetwork;
-use ::pnet_bandwhich_fork::datalink::DataLinkReceiver;
-use ::pnet_bandwhich_fork::datalink::NetworkInterface;
+use ::pnet::datalink::DataLinkReceiver;
+use ::pnet::datalink::NetworkInterface;
 use ::std::collections::HashMap;
 use ::std::future::Future;
 use ::std::net::{IpAddr, Ipv4Addr, SocketAddr};


### PR DESCRIPTION
#85 

Looks like there's some rename error in libpnet_bandwhich_fork? Not totally sure. The build is broken on Mac.
anyway I just found that we could fix the dependency problem without renaming, by adding these 2 lines to Cargo.toml:

```
[patch.crates-io]
pnet = { git = "https://github.com/zhangxp1998/libpnet.git", branch = 'bandwhich'}
```

This way we don't have to rename the `bandwhich` codebase or our fork of `libpnet`