### PR TITLE
fix(deps): upgrade to new pnet bandwhich fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "packet-builder 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_bandwhich_fork 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "procfs 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,12 +855,12 @@ dependencies = [
 
 [[package]]
 name = "pnet_bandwhich_fork"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_base_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_datalink_bandwhich_fork 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_sys_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_transport 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "pnet_datalink_bandwhich_fork"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1922,11 +1922,11 @@ dependencies = [
 "checksum pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pnet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cf9ef46222a90a9d1e35bb4fa208e1076c6663a02d8ecf3e264fd5001ab6e8e"
-"checksum pnet_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a72aace99497b045096dc467f55e819baccb60192caedb45619cdbe65bca4ea"
+"checksum pnet_bandwhich_fork 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e146697b998acfb2491f2524d1570f81f650a017402ce45b99539c5a5935a605"
 "checksum pnet_base 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d818b94d0897cd22f7a18f6c2a94f7ae1dfcedc194bf1665880f6c1155e051"
 "checksum pnet_base_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0886cdc1878c06687cbee7d3ed5045380e57b164bf69f036570559c07f6de88"
 "checksum pnet_datalink 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "557ff7deb5ad2b35ac17a495d629d64dfeacf02e7f4834974dceb5e2cc544d55"
-"checksum pnet_datalink_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf8691094ddce0573d0677a30860caddc533692dfc93570d03e737a76b579d50"
+"checksum pnet_datalink_bandwhich_fork 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "697cdb8110661cb4eea5aa08684ab50b0b2ab9b0ca88e9bcef2aa232f7c41369"
 "checksum pnet_macros 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d228096fd739d4e3e60dee9e1e4f07d9ae0f3f309c876834192538748e561e4"
 "checksum pnet_macros_support 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6158bbc3627b9ce01526f5ff8b9895224a0dc96c27baaf79cda0f703a4898ea"
 "checksum pnet_packet 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7efa93f5572ed735852737232ba7539977799861642aaba05de87b6a03dc0f74"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 exclude = ["src/tests/*", "demo.gif"]
 
 [dependencies]
-pnet_bandwhich_fork = "0.23.0"
+pnet_bandwhich_fork = "0.23.1"
 ipnetwork = "0.15.0"
 tui = "0.5"
 termion = "1.5"


### PR DESCRIPTION
Hey, so I fixed that one error in the fork mentioned here: https://github.com/imsnif/bandwhich/issues/85

There might be others, but those could require forking more pnet repositories, and I'd like to avoid that if it's not a must. This compiles for me on linux, but so did the previous one...

@zhangxp1998 - could you check and see if this compiles and tests for you on macOS? (and generally, if you have any comments, ofc?)