### PR TITLE
Fix parsing of IP-Packets from Layer3

### DIFF
--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -65,7 +65,9 @@ impl Sniffer {
             _ => {
                 let pkg = EthernetPacket::new(bytes)?;
                 match pkg.get_ethertype() {
-                    EtherTypes::Ipv4 => Self::handle_v4(Ipv4Packet::new(pkg.payload())?, &self.network_interface),
+                    EtherTypes::Ipv4 => {
+                        Self::handle_v4(Ipv4Packet::new(pkg.payload())?, &self.network_interface)
+                    }
                     _ => None,
                 }
             }
@@ -101,9 +103,7 @@ impl Sniffer {
         let to = SocketAddr::new(IpAddr::V4(ip_packet.get_destination()), destination_port);
 
         let connection = match direction {
-            Direction::Download => {
-                Connection::new(from, to.ip(), destination_port, protocol)?
-            },
+            Direction::Download => Connection::new(from, to.ip(), destination_port, protocol)?,
             Direction::Upload => Connection::new(to, from.ip(), source_port, protocol)?,
         };
         Some(Segment {

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -56,51 +56,61 @@ impl Sniffer {
     }
     pub fn next(&mut self) -> Option<Segment> {
         let bytes = self.network_frames.next().ok()?;
-        let packet = EthernetPacket::new(bytes)?;
-        match packet.get_ethertype() {
-            EtherType(2048) => {
-                let ip_packet = Ipv4Packet::new(packet.payload())?;
-                let (protocol, source_port, destination_port, data_length) =
-                    match ip_packet.get_next_level_protocol() {
-                        IpNextHeaderProtocol(6) => {
-                            let message = TcpPacket::new(ip_packet.payload())?;
-                            (
-                                Protocol::Tcp,
-                                message.get_source(),
-                                message.get_destination(),
-                                ip_packet.payload().len() as u128,
-                            )
-                        }
-                        IpNextHeaderProtocol(17) => {
-                            let datagram = UdpPacket::new(ip_packet.payload())?;
-                            (
-                                Protocol::Udp,
-                                datagram.get_source(),
-                                datagram.get_destination(),
-                                ip_packet.payload().len() as u128,
-                            )
-                        }
-                        _ => return None,
-                    };
-                let interface_name = self.network_interface.name.clone();
-                let direction = Direction::new(&self.network_interface.ips, &ip_packet);
-                let from = SocketAddr::new(IpAddr::V4(ip_packet.get_source()), source_port);
-                let to = SocketAddr::new(IpAddr::V4(ip_packet.get_destination()), destination_port);
+        let ip_packet = Ipv4Packet::new(&bytes)?;
+        let version = ip_packet.get_version();
 
-                let connection = match direction {
-                    Direction::Download => {
-                        Connection::new(from, to.ip(), destination_port, protocol)?
-                    }
-                    Direction::Upload => Connection::new(to, from.ip(), source_port, protocol)?,
-                };
-                Some(Segment {
-                    interface_name,
-                    connection,
-                    data_length,
-                    direction,
-                })
+        match version {
+            4 => Self::handle_v4(ip_packet, &self.network_interface),
+            6 => None, // FIXME v6 support!
+            _ => {
+                let pkg = EthernetPacket::new(bytes)?;
+                match pkg.get_ethertype() {
+                    EtherType(2048) => Self::handle_v4(Ipv4Packet::new(pkg.payload())?, &self.network_interface),
+                    _ => None,
+                }
             }
-            _ => None,
         }
+    }
+    fn handle_v4(ip_packet: Ipv4Packet, network_interface: &NetworkInterface) -> Option<Segment> {
+        let (protocol, source_port, destination_port, data_length) =
+            match ip_packet.get_next_level_protocol() {
+                IpNextHeaderProtocol(6) => {
+                    let message = TcpPacket::new(ip_packet.payload())?;
+                    (
+                        Protocol::Tcp,
+                        message.get_source(),
+                        message.get_destination(),
+                        ip_packet.payload().len() as u128,
+                    )
+                }
+                IpNextHeaderProtocol(17) => {
+                    let datagram = UdpPacket::new(ip_packet.payload())?;
+                    (
+                        Protocol::Udp,
+                        datagram.get_source(),
+                        datagram.get_destination(),
+                        ip_packet.payload().len() as u128,
+                    )
+                }
+                _ => return None,
+            };
+
+        let interface_name = network_interface.name.clone();
+        let direction = Direction::new(&network_interface.ips, &ip_packet);
+        let from = SocketAddr::new(IpAddr::V4(ip_packet.get_source()), source_port);
+        let to = SocketAddr::new(IpAddr::V4(ip_packet.get_destination()), destination_port);
+
+        let connection = match direction {
+            Direction::Download => {
+                Connection::new(from, to.ip(), destination_port, protocol)?
+            },
+            Direction::Upload => Connection::new(to, from.ip(), source_port, protocol)?,
+        };
+        Some(Segment {
+            interface_name,
+            connection,
+            data_length,
+            direction,
+        })
     }
 }

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -37,7 +37,7 @@ fn build_tcp_packet(
 }
 
 fn build_ip_tcp_packet(
-        source_ip: &str,
+    source_ip: &str,
     destination_ip: &str,
     source_port: u16,
     destination_port: u16,

--- a/src/tests/cases/snapshots/raw_mode__one_ip_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_ip_packet_of_traffic.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/cases/raw_mode.rs
+expression: formatted
+---
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 42/0 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 42/0 process: "1"
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 42/0 connections: 1
+


### PR DESCRIPTION
When having layer3-packets on an interface (e.g. when using WireGuard), no results will be displayed as the sniffer tries to parse those as layer2/ethernet packets. This change uses a hack inspired by `<libpnet/examples/packetdump.rs>` which tries to parse the current frame as  IP-Packet and if that doesn't work, the packet will be treated as ethernet packet.

To reproduce this issue I'd recommend to create a VM with a WireGuard Interface and then try to capture packets from the interface with `bandwhich`.