### PR TITLE
Mention `setcap(8)`-fix in EPERM error on Linux

### DIFF
--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -110,9 +110,7 @@ pub fn get_input(
         for iface in network_frames {
             if let Some(iface_error) = iface.err() {
                 if let ErrorKind::PermissionDenied = iface_error.kind() {
-                    failure::bail!(
-                        "Insufficient permissions to listen on network interface(s). Try running with sudo.",
-                    )
+                    failure::bail!(eperm_message())
                 }
             }
         }
@@ -140,4 +138,24 @@ pub fn get_input(
         cleanup,
         write_to_stdout,
     })
+}
+
+#[inline]
+#[cfg(target_os = "macos")]
+fn eperm_message() -> &'static str {
+    "Insufficient permissions to listen on network interface(s). Try running with sudo."
+}
+
+#[inline]
+#[cfg(target_os = "linux")]
+fn eperm_message() -> &'static str {
+    r#"
+    Insufficient permissions to listen on network interface(s). You can work around
+    this issue like this:
+
+    * Try running `bandwhich` with `sudo`
+
+    * Build a `setcap(8)` wrapper for `bandwhich` with the following rules:
+        `cap_net_raw,cap_net_admin+ep`
+    "#
 }


### PR DESCRIPTION
This is already mentioned in the README, but I figured that it might be
helpful to point linux-users to this if they try to run `bandwhich`
right after installing it and encountering this kind of error.