### PR TITLE
fix(ui-state): do not overcalculate bandwidth and connections

### DIFF
--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -150,7 +150,7 @@ impl UIState {
                 }
             }
         }
-        let divide_by = if self.utilization_data.len() == 0 {
+        let divide_by = if self.utilization_data.is_empty() {
             1 as u128
         } else {
             self.utilization_data.len() as u128

--- a/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
@@ -8,10 +8,10 @@ connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/d
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 17/18 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 28/30 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 17/18 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 2
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 31/32 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 22/27 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 2
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
@@ -8,10 +8,10 @@ connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/d
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/19 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/19 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/35 connections: 2
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/30 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/35 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/30 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/35 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/30 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/35 connections: 2
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/30 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/35 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/30 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -8,10 +8,10 @@ connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/d
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 17/18 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 28/30 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 17/18 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 2
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 31/32 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 22/27 process: "5"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 2
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
@@ -5,7 +5,7 @@ expression: formatted
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/31 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/31 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/31 process: "1"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/31 connections: 2
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/31 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
@@ -8,10 +8,10 @@ connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (t
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 17/18 process: "5"
 remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 28/30 connections: 1
 remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 17/18 connections: 1
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 2
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 2
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 1
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 31/32 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 22/27 process: "5"
-remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 31/32 connections: 2
-remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 22/27 connections: 2
+remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 31/32 connections: 1
+remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 22/27 connections: 1
 

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       49Bps / 51Bps                                                                                                                                                          
+                       24Bps / 25Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              184Bps                                                                                                                                                          
+                              92Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              184Bps                                                                                   
+                              92Bps                                                                                    
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              184Bps                                                                                   
+                              92Bps                                                                                    
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_full_height-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              184Bps                                                                                                                 
+                              92Bps                                                                                                                  
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_150_width_under_30_height-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              184Bps                                                                                                                 
+                              92Bps                                                                                                                  
                                                                                                                                                      
                                                                                                                                                      
                                                                                                                                                      

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              95Bps                                                                                                                                                           
+                              47Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              83Bps                                                                                                                                                           
+                              41Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              91Bps                                                                                                                                                           
+                              45Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              184Bps                                                                                                                                                          
+                              92Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       160Bps / 180Bps                                                                                                                                                        
+                       53      60                                                                                                                                                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                     2                     31       2                                                                                     31       2          
-                                                     2                     22      27                                                                                     22      27          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                           31       2                                                                                     31       2          
+                                                                           22      27                                                                                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                    2                     31       2          
-                                                                                                                                                    2                     22      27          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                          31       2          
+                                                                                                                                                                          22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       91Bps / 98Bps                                                                                                                                                          
+                       45Bps / 49Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       42Bps / 0Bps                                                                                                                                                           
+                       21Bps / 0Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              92Bps                                                                                                                                                           
+                              46Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                              195Bps                                                                                                                                                          
+                              65                                                                                                                                                              
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                     2                            35                                                                                             35           
-                                                     2                            30                                                                                             30           
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                                  35                                                                                             35           
+                                                                                  30                                                                                             30           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                    2                            35           
-                                                                                                                                                    2                            30           
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                 35           
+                                                                                                                                                                                 30           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              83Bps                                                                                                                                                           
+                              41Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       160Bps / 180Bps                                                                                                                                                        
+                       53      60                                                                                                                                                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                     2                     31       2                                                                                     31       2          
-                                                     2                     22      27                                                                                     22      27          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                           31       2                                                                                     31       2          
+                                                                           22      27                                                                                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                    2                     31       2          
-                                                                                                                                                    2                     22      27          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                          31       2          
+                                                                                                                                                                          22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       91Bps / 98Bps                                                                                                                                                          
+                       45Bps / 49Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
@@ -2,15 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                              95                                                                                                                                                              
+                              31                                                                                                                                                              
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                     2                            31                                                                                             31           
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                                  31                                                                                             31           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +26,11 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                    2                            31           
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                 31           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              44Bps                                                                                                                                                           
+                              22Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
@@ -2,16 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       160Bps / 180Bps                                                                                                                                                        
+                       53      60                                                                                                                                                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                     2                     31       2                                                                                     31       2          
-                                                     2                     22      27                                                                                     22      27          
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+                                                                           31       2                                                                                     31       2          
+                                                                           22      27                                                                                     22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,8 +26,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                    2                     31       2          
-                                                                                                                                                    2                     22      27          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                          31       2          
+                                                                                                                                                                          22      27          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       91Bps / 98Bps                                                                                                                                                          
+                       45Bps / 49Bps                                                                                                                                                          
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       42Bps / 0Bps                                                                                                                                                           
+                       21Bps / 0Bps                                                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               


### PR DESCRIPTION
So, yesterday I broke master with this: https://github.com/imsnif/bandwhich/pull/77

What that PR essentially does is save a cache of the last 5 states and then display their average bandwidth.

I forgot to take the total bandwidth into account, so until this PR master shows ~5 times as much total bandwidth as there actually is.

I also forgot to take the connection count into account, and so in master the connections were counted once for every state.

The total bandwidth calculation was a fairly straightforward fix: just divide it by the amount of cached states like we do with the rest of the bandwidth.

With the connection count, dividing would not do since we don't want a connection average of the past N seconds, but an exact count (of the past N seconds). I did this here by only counting a connection the first time we see it.

So, umm... oops. :)