### PR TITLE
README: fix setcap syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cargo install bandwhich
 ```
 
 This installs `bandwhich` to `~/.cargo/bin/bandwhich` but you need root priviliges to run `bandwhich`. To fix that, there are a few options:
-- Give the executable elevated permissions: `sudo setcap cap_net_raw,cap_net_admin=+ep ~/.cargo/bin/bandwhich`
+- Give the executable elevated permissions: `sudo setcap cap_net_raw,cap_net_admin+ep ~/.cargo/bin/bandwhich`
 - Run `sudo ~/.cargo/bin/bandwhich` instead of just `bandwhich`
 - Create a symlink: `sudo ln -s ~/.cargo/bin/bandwhich /usr/local/bin/` (or another path on root's PATH)
 - Set root's PATH to match your own `sudo env "PATH=$PATH" bandwhich`


### PR DESCRIPTION
setcap+=ep did not work for me, needed to take off the equals sign to work

```sh
> sudo setcap cap_net_raw,cap_net_admin+=ep /sbin/bandwhich
fatal error: Invalid argument
usage: setcap [-q] [-v] [-n <rootid>] (-r|-|<caps>) <filename> [ ... (-r|-|<capsN>) <filenameN> ]

 Note <filename> must be a regular (non-symlink) file.
```

this worked:

```
$ sudo setcap cap_net_raw,cap_net_admin+ep /sbin/bandwhich
```
