### PR TITLE
(#127) Degrading retry DNS resolve. Needs tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,10 @@ To set up your development environment:
 1. Clone the project
 2. `cargo run`, or if you prefer `cargo run -- -i <network interface name>` (you can often find out the name with `ifconfig` or `iwconfig`). You might need root privileges to run this application, so be sure to use (for example) sudo.
 
-To run tests: `cargo test`
-
-After tests, check the formatting: `cargo fmt -- --check`
+Pre-pull request checklist:
+ - Run tests: `cargo test`
+ - Check the formatting: `cargo fmt -- --check`
+ - Run linter: `cargo clippy --all-targets --all-features -- -D warnings`
 
 Note that at the moment the tests do not test the os layer (anything in the `os` folder).
 

--- a/src/network/dns/client.rs
+++ b/src/network/dns/client.rs
@@ -31,7 +31,6 @@ impl Client {
 
         let handle = Builder::new().name("resolver".into()).spawn({
             let cache = cache.clone();
-            let pending = pending.clone();
             move || {
                 runtime.block_on(async {
                     let resolver = Arc::new(resolver);

--- a/src/network/dns/client.rs
+++ b/src/network/dns/client.rs
@@ -10,7 +10,7 @@ use tokio::{
     sync::mpsc::{self, Sender},
 };
 
-type PendingAddrs = HashMap<IpAddr,f32>;
+type PendingAddrs = HashMap<IpAddr, f32>;
 
 const CHANNEL_SIZE: usize = 1_000;
 
@@ -42,10 +42,11 @@ impl Client {
                             .filter(|ip| {
                                 let mut pending = pending.lock().unwrap().clone();
                                 let cnt = pending.entry(*ip).or_insert(0.0);
-                                let pwr_of2 :bool = (*cnt == 0.0) | (cnt.log2() % 1.0 == 0.0);
+                                let pwr_of2: bool = (*cnt == 0.0) | (cnt.log2() % 1.0 == 0.0);
                                 *cnt += 1.0;
                                 pwr_of2
-                            }).collect::<Vec<_>>();
+                            })
+                            .collect::<Vec<_>>();
 
                         for ip in ips {
                             tokio::spawn({


### PR DESCRIPTION
Hi Friends,

I've only tested this manually. I still need to grok how the snapshot testing infrastructure works and then figure out how to shoehorn some dns resolve failures into a test. While I do that, I figure I might as well send this for at least a code review because I moved some stuff around and my approach should be reviewed as well. 

I moved adding ips to `pending` out of the `Client::resolve` function and into the block defining `handle`. All ips are added to pending along with a counter for how many times the client has been asked to resolve the ip. If it is the first attempt or an attempt that is a power of 2, an actual dns call will be made. If an ip is resolved it will be removed from `pending`.  This will indirectly give the increasing retry timeout suggested in the previous comment. e.g. 2, 4, 8, 16 seconds.

Let me know if any of this looks weird. I am still getting used to borrowing/clone etc. and I have discovered doing simple stuff with numbers in rust makes me want to stab hot pokers into my eyeballs. I think I just need to get used to it.
 