### PR TITLE
fix(cli): collect table args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,14 @@ pub struct Opt {
 
 #[derive(StructOpt, Debug)]
 pub struct RenderOpts {
+    #[structopt(short, long)]
+    /// Show processes table only
     processes: bool,
+    #[structopt(short, long)]
+    /// Show connections table only
     connections: bool,
+    #[structopt(short, long)]
+    /// Show remote addresses table only
     addresses: bool,
 }
 


### PR DESCRIPTION
This is a quick hotfix.

After some of my comments on this: https://github.com/imsnif/bandwhich/pull/107, we were no longer able to properly select tables from the CLI. Instead, no matter what table we selected, only the processes table was shown.

Now it works. I'm going to merge this because it's just a quick hotfix to CLI args.