### PR TITLE
Add accumlated usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "bandwhich"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "bandwhich"
-version = "0.13.0"
+version = "0.12.0"
 dependencies = [
  "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 name = "bandwhich"
 description = "Display current network utilization by process, connection and remote IP/hostname"
-version = "0.12.0"
+version = "0.13.0"
 homepage = "https://github.com/imsnif/bandwhich"
 repository = "https://github.com/imsnif/bandwhich"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 name = "bandwhich"
 description = "Display current network utilization by process, connection and remote IP/hostname"
-version = "0.13.0"
+version = "0.12.0"
 homepage = "https://github.com/imsnif/bandwhich"
 repository = "https://github.com/imsnif/bandwhich"
 readme = "README.md"

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -1,17 +1,22 @@
 use ::std::fmt;
 
-pub struct DisplayBandwidth(pub f64);
+// Should we make a `DisplayMode` enum with `Rate` and `Total`?
+// Instead of the ambiguous bool?
+
+// This might be better as a traditional struct now?
+pub struct DisplayBandwidth(pub f64, pub bool);
 
 impl fmt::Display for DisplayBandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let suffix = if self.1 { "" } else { "ps" }; // Should this be the other way around?
         if self.0 > 999_999_999.0 {
-            write!(f, "{:.2}GBps", self.0 / 1_000_000_000.0)
+            write!(f, "{:.2}GB{}", self.0 / 1_000_000_000.0, suffix)
         } else if self.0 > 999_999.0 {
-            write!(f, "{:.2}MBps", self.0 / 1_000_000.0)
+            write!(f, "{:.2}MB{}", self.0 / 1_000_000.0, suffix)
         } else if self.0 > 999.0 {
-            write!(f, "{:.2}KBps", self.0 / 1000.0)
+            write!(f, "{:.2}KB{}", self.0 / 1000.0, suffix)
         } else {
-            write!(f, "{}Bps", self.0)
+            write!(f, "{}B{}", self.0, suffix)
         }
     }
 }

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -7,7 +7,7 @@ pub struct DisplayBandwidth {
 
 impl fmt::Display for DisplayBandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let suffix = if self.as_rate { "" } else { "ps" };
+        let suffix = if self.as_rate { "ps" } else { "" };
         if self.bandwidth > 999_999_999.0 {
             write!(f, "{:.2}GB{}", self.bandwidth / 1_000_000_000.0, suffix)
         } else if self.bandwidth > 999_999.0 {

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -1,22 +1,21 @@
 use ::std::fmt;
 
-// Should we make a `DisplayMode` enum with `Rate` and `Total`?
-// Instead of the ambiguous bool?
-
-// This might be better as a traditional struct now?
-pub struct DisplayBandwidth(pub f64, pub bool);
+pub struct DisplayBandwidth {
+    pub bandwidth: f64,
+    pub as_rate: bool,
+}
 
 impl fmt::Display for DisplayBandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let suffix = if self.1 { "" } else { "ps" }; // Should this be the other way around?
-        if self.0 > 999_999_999.0 {
-            write!(f, "{:.2}GB{}", self.0 / 1_000_000_000.0, suffix)
-        } else if self.0 > 999_999.0 {
-            write!(f, "{:.2}MB{}", self.0 / 1_000_000.0, suffix)
-        } else if self.0 > 999.0 {
-            write!(f, "{:.2}KB{}", self.0 / 1000.0, suffix)
+        let suffix = if self.as_rate { "" } else { "ps" };
+        if self.bandwidth > 999_999_999.0 {
+            write!(f, "{:.2}GB{}", self.bandwidth / 1_000_000_000.0, suffix)
+        } else if self.bandwidth > 999_999.0 {
+            write!(f, "{:.2}MB{}", self.bandwidth / 1_000_000.0, suffix)
+        } else if self.bandwidth > 999.0 {
+            write!(f, "{:.2}KB{}", self.bandwidth / 1000.0, suffix)
         } else {
-            write!(f, "{}B{}", self.0, suffix)
+            write!(f, "{}B{}", self.bandwidth, suffix)
         }
     }
 }

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -9,8 +9,8 @@ use ::tui::widgets::{Block, Borders, Row, Widget};
 use crate::display::{Bandwidth, DisplayBandwidth, UIState};
 use crate::network::{display_connection_string, display_ip_or_host};
 
-use ::std::net::IpAddr;
-use std::iter::FromIterator;
+use ::std::net::IpAddr; // Just curious, why not just std::net::IpAddr?
+use std::iter::FromIterator; // This line doesn't have the leading :: here
 
 fn display_upload_and_download(bandwidth: &impl Bandwidth, total: bool) -> String {
     format!(
@@ -20,6 +20,7 @@ fn display_upload_and_download(bandwidth: &impl Bandwidth, total: bool) -> Strin
     )
 }
 
+// Why is this returning the sorted list when it mutates things?
 fn sort_by_bandwidth<'a, T>(
     list: &'a mut Vec<(T, &impl Bandwidth)>,
 ) -> &'a Vec<(T, &'a impl Bandwidth)> {
@@ -38,6 +39,12 @@ fn sort_by_bandwidth<'a, T>(
     });
     list
 }
+// I'd suggest using this:
+// fn sort_by_bandwidth<T>(list: &mut Vec<(T, impl Bandwidth)>) {
+//     list.sort_by_key(|(_, b)| {
+//         cmp::max(b.get_total_bytes_downloaded(), b.get_total_bytes_uploaded())
+//     });
+// }
 
 pub enum ColumnCount {
     Two,

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -9,8 +9,8 @@ use ::tui::widgets::{Block, Borders, Row, Widget};
 use crate::display::{Bandwidth, DisplayBandwidth, UIState};
 use crate::network::{display_connection_string, display_ip_or_host};
 
-use ::std::net::IpAddr; // Just curious, why not just std::net::IpAddr?
-use std::iter::FromIterator; // This line doesn't have the leading :: here
+use ::std::iter::FromIterator;
+use ::std::net::IpAddr;
 
 fn display_upload_and_download(bandwidth: &impl Bandwidth, total: bool) -> String {
     format!(

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -9,45 +9,21 @@ use ::tui::widgets::{Block, Borders, Row, Widget};
 use crate::display::{Bandwidth, DisplayBandwidth, UIState};
 use crate::network::{display_connection_string, display_ip_or_host};
 
-use ::std::iter::FromIterator;
 use ::std::net::IpAddr;
 
 fn display_upload_and_download(bandwidth: &impl Bandwidth, total: bool) -> String {
     format!(
         "{} / {}",
-        DisplayBandwidth(bandwidth.get_total_bytes_uploaded() as f64, total),
-        DisplayBandwidth(bandwidth.get_total_bytes_downloaded() as f64, total)
+        DisplayBandwidth{
+            bandwidth: bandwidth.get_total_bytes_uploaded() as f64,
+            as_rate: !total,
+        },
+        DisplayBandwidth{
+            bandwidth: bandwidth.get_total_bytes_downloaded() as f64,
+            as_rate: !total,
+        },
     )
 }
-
-// Why is this returning the sorted list when it mutates things?
-fn sort_by_bandwidth<'a, T>(
-    list: &'a mut Vec<(T, &impl Bandwidth)>,
-) -> &'a Vec<(T, &'a impl Bandwidth)> {
-    list.sort_by(|(_, a), (_, b)| {
-        let a_highest = if a.get_total_bytes_downloaded() > a.get_total_bytes_uploaded() {
-            a.get_total_bytes_downloaded()
-        } else {
-            a.get_total_bytes_uploaded()
-        };
-        let b_highest = if b.get_total_bytes_downloaded() > b.get_total_bytes_uploaded() {
-            b.get_total_bytes_downloaded()
-        } else {
-            b.get_total_bytes_uploaded()
-        };
-        b_highest.cmp(&a_highest)
-    });
-    list
-}
-// I'd suggest using this:
-// fn sort_by_bandwidth<T>(list: &mut Vec<(T, impl Bandwidth)>) {
-//     list.sort_by_key(|(_, b)| {
-//         cmp::Reverse(cmp::max(
-//             b.get_total_bytes_downloaded(),
-//             b.get_total_bytes_uploaded(),
-//         ))
-//     });
-// }
 
 pub enum ColumnCount {
     Two,
@@ -87,9 +63,8 @@ fn truncate_middle(row: &str, max_length: u16) -> String {
 
 impl<'a> Table<'a> {
     pub fn create_connections_table(state: &UIState, ip_to_host: &HashMap<IpAddr, String>) -> Self {
-        let mut connections_list = Vec::from_iter(&state.connections);
-        sort_by_bandwidth(&mut connections_list);
-        let connections_rows = connections_list
+        let connections_rows = state
+            .connections
             .iter()
             .map(|(connection, connection_data)| {
                 vec![
@@ -99,7 +74,7 @@ impl<'a> Table<'a> {
                         &connection_data.interface_name,
                     ),
                     connection_data.process_name.to_string(),
-                    display_upload_and_download(*connection_data, state.cumulative_mode),
+                    display_upload_and_download(connection_data, state.cumulative_mode),
                 ]
             })
             .collect();
@@ -142,15 +117,14 @@ impl<'a> Table<'a> {
         }
     }
     pub fn create_processes_table(state: &UIState) -> Self {
-        let mut processes_list = Vec::from_iter(&state.processes);
-        sort_by_bandwidth(&mut processes_list);
-        let processes_rows = processes_list
+        let processes_rows = state
+            .processes
             .iter()
             .map(|(process_name, data_for_process)| {
                 vec![
                     (*process_name).to_string(),
                     data_for_process.connection_count.to_string(),
-                    display_upload_and_download(*data_for_process, state.cumulative_mode),
+                    display_upload_and_download(data_for_process, state.cumulative_mode),
                 ]
             })
             .collect();
@@ -196,16 +170,15 @@ impl<'a> Table<'a> {
         state: &UIState,
         ip_to_host: &HashMap<IpAddr, String>,
     ) -> Self {
-        let mut remote_addresses_list = Vec::from_iter(&state.remote_addresses);
-        sort_by_bandwidth(&mut remote_addresses_list);
-        let remote_addresses_rows = remote_addresses_list
+        let remote_addresses_rows = state
+            .remote_addresses
             .iter()
             .map(|(remote_address, data_for_remote_address)| {
-                let remote_address = display_ip_or_host(**remote_address, &ip_to_host);
+                let remote_address = display_ip_or_host(*remote_address, &ip_to_host);
                 vec![
                     remote_address,
                     data_for_remote_address.connection_count.to_string(),
-                    display_upload_and_download(*data_for_remote_address, state.cumulative_mode),
+                    display_upload_and_download(data_for_remote_address, state.cumulative_mode),
                 ]
             })
             .collect();

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -14,11 +14,11 @@ use ::std::net::IpAddr;
 fn display_upload_and_download(bandwidth: &impl Bandwidth, total: bool) -> String {
     format!(
         "{} / {}",
-        DisplayBandwidth{
+        DisplayBandwidth {
             bandwidth: bandwidth.get_total_bytes_uploaded() as f64,
             as_rate: !total,
         },
-        DisplayBandwidth{
+        DisplayBandwidth {
             bandwidth: bandwidth.get_total_bytes_downloaded() as f64,
             as_rate: !total,
         },

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -42,7 +42,10 @@ fn sort_by_bandwidth<'a, T>(
 // I'd suggest using this:
 // fn sort_by_bandwidth<T>(list: &mut Vec<(T, impl Bandwidth)>) {
 //     list.sort_by_key(|(_, b)| {
-//         cmp::max(b.get_total_bytes_downloaded(), b.get_total_bytes_uploaded())
+//         cmp::Reverse(cmp::max(
+//             b.get_total_bytes_downloaded(),
+//             b.get_total_bytes_uploaded(),
+//         ))
 //     });
 // }
 

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -12,11 +12,11 @@ use crate::network::{display_connection_string, display_ip_or_host};
 use ::std::net::IpAddr;
 use std::iter::FromIterator;
 
-fn display_upload_and_download(bandwidth: &impl Bandwidth) -> String {
+fn display_upload_and_download(bandwidth: &impl Bandwidth, total: bool) -> String {
     format!(
         "{} / {}",
-        DisplayBandwidth(bandwidth.get_total_bytes_uploaded() as f64),
-        DisplayBandwidth(bandwidth.get_total_bytes_downloaded() as f64)
+        DisplayBandwidth(bandwidth.get_total_bytes_uploaded() as f64, total),
+        DisplayBandwidth(bandwidth.get_total_bytes_downloaded() as f64, total)
     )
 }
 
@@ -89,12 +89,12 @@ impl<'a> Table<'a> {
                         &connection_data.interface_name,
                     ),
                     connection_data.process_name.to_string(),
-                    display_upload_and_download(*connection_data),
+                    display_upload_and_download(*connection_data, state.cumulative_mode),
                 ]
             })
             .collect();
         let connections_title = "Utilization by connection";
-        let connections_column_names = &["Connection", "Process", "Rate Up / Down"];
+        let connections_column_names = &["Connection", "Process", "Up / Down"];
         let mut breakpoints = BTreeMap::new();
         breakpoints.insert(
             0,
@@ -140,12 +140,12 @@ impl<'a> Table<'a> {
                 vec![
                     (*process_name).to_string(),
                     data_for_process.connection_count.to_string(),
-                    display_upload_and_download(*data_for_process),
+                    display_upload_and_download(*data_for_process, state.cumulative_mode),
                 ]
             })
             .collect();
         let processes_title = "Utilization by process name";
-        let processes_column_names = &["Process", "Connections", "Rate Up / Down"];
+        let processes_column_names = &["Process", "Connections", "Up / Down"];
         let mut breakpoints = BTreeMap::new();
         breakpoints.insert(
             0,
@@ -195,12 +195,12 @@ impl<'a> Table<'a> {
                 vec![
                     remote_address,
                     data_for_remote_address.connection_count.to_string(),
-                    display_upload_and_download(*data_for_remote_address),
+                    display_upload_and_download(*data_for_remote_address, state.cumulative_mode),
                 ]
             })
             .collect();
         let remote_addresses_title = "Utilization by remote address";
-        let remote_addresses_column_names = &["Remote Address", "Connections", "Rate Up / Down"];
+        let remote_addresses_column_names = &["Remote Address", "Connections", "Up / Down"];
         let mut breakpoints = BTreeMap::new();
         breakpoints.insert(
             0,

--- a/src/display/components/total_bandwidth.rs
+++ b/src/display/components/total_bandwidth.rs
@@ -25,11 +25,11 @@ impl<'a> TotalBandwidth<'a> {
             [Text::styled(
                 format!(
                     " Total Up / Down: {} / {} {}",
-                    DisplayBandwidth{
+                    DisplayBandwidth {
                         bandwidth: self.state.total_bytes_uploaded as f64,
                         as_rate: !c_mode,
                     },
-                    DisplayBandwidth{
+                    DisplayBandwidth {
                         bandwidth: self.state.total_bytes_downloaded as f64,
                         as_rate: !c_mode,
                     },

--- a/src/display/components/total_bandwidth.rs
+++ b/src/display/components/total_bandwidth.rs
@@ -25,8 +25,14 @@ impl<'a> TotalBandwidth<'a> {
             [Text::styled(
                 format!(
                     " Total Up / Down: {} / {} {}",
-                    DisplayBandwidth(self.state.total_bytes_uploaded as f64, c_mode),
-                    DisplayBandwidth(self.state.total_bytes_downloaded as f64, c_mode),
+                    DisplayBandwidth{
+                        bandwidth: self.state.total_bytes_uploaded as f64,
+                        as_rate: !c_mode,
+                    },
+                    DisplayBandwidth{
+                        bandwidth: self.state.total_bytes_downloaded as f64,
+                        as_rate: !c_mode,
+                    },
                     paused_str
                 ),
                 Style::default().fg(color).modifier(Modifier::BOLD),

--- a/src/display/components/total_bandwidth.rs
+++ b/src/display/components/total_bandwidth.rs
@@ -13,6 +13,7 @@ pub struct TotalBandwidth<'a> {
 
 impl<'a> TotalBandwidth<'a> {
     pub fn render(&self, frame: &mut Frame<impl Backend>, rect: Rect) {
+        let c_mode = self.state.cumulative_mode;
         let title_text = {
             let paused_str = if self.paused { "[PAUSED]" } else { "" };
             let color = if self.paused {
@@ -23,9 +24,9 @@ impl<'a> TotalBandwidth<'a> {
 
             [Text::styled(
                 format!(
-                    " Total Rate Up / Down: {} / {} {}",
-                    DisplayBandwidth(self.state.total_bytes_uploaded as f64),
-                    DisplayBandwidth(self.state.total_bytes_downloaded as f64),
+                    " Total Up / Down: {} / {} {}",
+                    DisplayBandwidth(self.state.total_bytes_uploaded as f64, c_mode),
+                    DisplayBandwidth(self.state.total_bytes_downloaded as f64, c_mode),
                     paused_str
                 ),
                 Style::default().fg(color).modifier(Modifier::BOLD),

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -30,12 +30,11 @@ where
         let mut terminal = Terminal::new(terminal_backend).unwrap();
         terminal.clear().unwrap();
         terminal.hide_cursor().unwrap();
+        let mut state: UIState = Default::default();
+        state.cumulative_mode = opts.total_utilization;
         Ui {
             terminal,
-            state: UIState {
-                cumulative_mode: opts.total_utilization,
-                ..Default::default()
-            },
+            state,
             ip_to_host: Default::default(),
             opts,
         }

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -33,7 +33,7 @@ where
         Ui {
             terminal,
             state: UIState {
-                cumulative_mode: opts.total,
+                cumulative_mode: opts.total_utilization,
                 ..Default::default()
             },
             ip_to_host: Default::default(),

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -32,7 +32,10 @@ where
         terminal.hide_cursor().unwrap();
         Ui {
             terminal,
-            state: Default::default(),
+            state: UIState {
+                cumulative_mode: opts.total,
+                ..Default::default()
+            },
             ip_to_host: Default::default(),
             opts,
         }

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -235,6 +235,9 @@ fn prune_map(map: &mut BTreeMap<impl Eq + Ord + Clone, impl Bandwidth + Clone>) 
 // This is duplicated from table.rs temporarily
 fn sort_by_bandwidth<T>(list: &mut Vec<(T, impl Bandwidth)>) {
     list.sort_by_key(|(_, b)| {
-        cmp::max(b.get_total_bytes_downloaded(), b.get_total_bytes_uploaded())
+        cmp::Reverse(cmp::max(
+            b.get_total_bytes_downloaded(),
+            b.get_total_bytes_uploaded(),
+        ))
     });
 }

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -1,12 +1,12 @@
 use ::std::cmp;
 use ::std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use ::std::iter::FromIterator;
 use ::std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::iter::FromIterator;
 
 use crate::network::{Connection, LocalSocket, Utilization};
 
 static RECALL_LENGTH: usize = 5;
-static MAX_BANDWIDTH_ITEMS: usize = 1000; // Would this be better suited as a `const`?
+static MAX_BANDWIDTH_ITEMS: usize = 1000;
 
 pub trait Bandwidth {
     fn get_total_bytes_downloaded(&self) -> u128;
@@ -43,8 +43,6 @@ impl ConnectionData {
     }
 }
 
-// These impls seem super repetitive, should we add either a macro or make Bandwidth
-// a nested struct in NetworkData and ConnectionData?
 impl Bandwidth for ConnectionData {
     fn get_total_bytes_downloaded(&self) -> u128 {
         self.total_bytes_downloaded
@@ -91,7 +89,7 @@ pub struct UIState {
     pub total_bytes_downloaded: u128,
     pub total_bytes_uploaded: u128,
     pub cumulative_mode: bool,
-    pub utilization_data: VecDeque<UtilizationData>, // This needs to be public for the struct-update syntax
+    pub utilization_data: VecDeque<UtilizationData>,
 }
 
 impl UIState {
@@ -137,6 +135,7 @@ impl UIState {
         for state in self.utilization_data.iter().rev() {
             let connections_to_procs = &state.connections_to_procs;
             let network_utilization = &state.network_utilization;
+
             for (connection, connection_info) in &network_utilization.connections {
                 let connection_previously_seen = !seen_connections.insert(connection);
                 let connection_data = connections.entry(connection.clone()).or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,9 @@ pub struct RenderOpts {
     #[structopt(short, long)]
     /// Show remote addresses table only
     addresses: bool,
+    #[structopt(short, long)]
+    /// Show total (cumulative) usages
+    total: bool, // I don't like `total` as much as `cumulative`, but -c is taken?
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ pub struct RenderOpts {
     addresses: bool,
     #[structopt(short, long)]
     /// Show total (cumulative) usages
-    total: bool, // I don't like `total` as much as `cumulative`, but -c is taken?
+    total_utilization: bool,
 }
 
 fn main() {

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -207,7 +207,7 @@ fn multiple_processes_with_multiple_connections() {
             "10.0.0.2",
             1337,
             4435,
-            b"Awesome, I'm from 3.3.3.3",
+            b"Greetings traveller, I'm from 3.3.3.3",
         )),
         Some(build_tcp_packet(
             "2.2.2.2",

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -580,6 +580,7 @@ fn no_resolve_mode() {
             addresses: false,
             connections: false,
             processes: false,
+            total: false,
         },
     };
     start(backend, os_input, opts);

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -580,7 +580,7 @@ fn no_resolve_mode() {
             addresses: false,
             connections: false,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
     start(backend, os_input, opts);

--- a/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
@@ -3,7 +3,7 @@ source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/47 connections: 2
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/25 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/47 connections: 2
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
-process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
-process: <TIMESTAMP_REMOVED> "2" up/down Bps: 0/21 connections: 1
 process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/26 connections: 1
+process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/22 connections: 1
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
+process: <TIMESTAMP_REMOVED> "2" up/down Bps: 0/21 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/26 process: "4"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/22 process: "5"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4432 => 4.4.4.4:1337 (tcp) up/down Bps: 0/21 process: "2"
-remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/26 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/22 connections: 1
+remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 4.4.4.4 up/down Bps: 0/21 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
@@ -2,16 +2,16 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/28 connections: 1
 process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/26 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
-process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/22 connections: 1
 process: <TIMESTAMP_REMOVED> "2" up/down Bps: 0/21 connections: 1
+connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/28 process: "5"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/26 process: "4"
-connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/22 process: "5"
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4432 => 4.4.4.4:1337 (tcp) up/down Bps: 0/21 process: "2"
+remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/28 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/26 connections: 1
-remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 4.4.4.4 up/down Bps: 0/21 connections: 1
 

--- a/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
@@ -3,7 +3,7 @@ source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/46 connections: 2
-connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/24 process: "1"
+connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/46 connections: 2
 

--- a/src/tests/cases/snapshots/ui__basic_only_addresses.snap
+++ b/src/tests/cases/snapshots/ui__basic_only_addresses.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by remote address───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Remote Address                                                                                                        Connections                   Rate Up / Down                          │
+│Remote Address                                                                                                        Connections                   Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__basic_only_connections.snap
+++ b/src/tests/cases/snapshots/ui__basic_only_connections.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__basic_only_processes.snap
+++ b/src/tests/cases/snapshots/ui__basic_only_processes.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                                                       Connections                                       Rate Up / Down                                              │
+│Process                                                                       Connections                                       Up / Down                                                   │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__basic_startup.snap
+++ b/src/tests/cases/snapshots/ui__basic_startup.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       24Bps / 25Bps                                                                                                                                                          
+                  24Bps / 25Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__bi_directional_traffic.snap
+++ b/src/tests/cases/snapshots/ui__bi_directional_traffic.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
@@ -2,12 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                         92Bps                                                                                                                                                                
+                         98Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+ 5                           1                           0Bps / 28Bps                           3.3.3.3                                 1                     0Bps / 28Bps                    
  4                           1                           0Bps / 26Bps                           2.2.2.2                                 1                     0Bps / 26Bps                    
- 5                           1                           0Bps / 22Bps                           3.3.3.3                                 1                     0Bps / 22Bps                    
  1                           1                           0Bps / 22Bps                           1.1.1.1                                 1                     0Bps / 22Bps                    
  2                           1                           0Bps / 21Bps                           4.4.4.4                                 1                     0Bps / 21Bps                    
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height-2.snap
@@ -2,13 +2,13 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              92Bps                                                                                                                                                           
+                         92Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
  4                           1                           0Bps / 26Bps                           2.2.2.2                                 1                     0Bps / 26Bps                    
- 1                           1                           0Bps / 22Bps                           1.1.1.1                                 1                     0Bps / 22Bps                    
  5                           1                           0Bps / 22Bps                           3.3.3.3                                 1                     0Bps / 22Bps                    
+ 1                           1                           0Bps / 22Bps                           1.1.1.1                                 1                     0Bps / 22Bps                    
  2                           1                           0Bps / 21Bps                           4.4.4.4                                 1                     0Bps / 21Bps                    
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__layout_full_width_under_30_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_full_width_under_30_height.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              92Bps                                                                                    
+                         92Bps                                                                                         
                                                                                                                        
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height-2.snap
@@ -2,13 +2,13 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                         92Bps                                                                                         
+                         98Bps                                                                                         
                                                                                                                        
                                                                                                                        
                                                                                                                        
+ 5                                                     1                         0Bps / 28Bps                          
  4                                                     1                         0Bps / 26Bps                          
  1                                                     1                         0Bps / 22Bps                          
- 5                                                     1                         0Bps / 22Bps                          
  2                                                     1                         0Bps / 21Bps                          
                                                                                                                        
                                                                                                                        
@@ -30,9 +30,9 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                        
                                                                                                                        
                                                                                                                        
+ 3.3.3.3                                                             1                   0Bps / 28Bps                  
  2.2.2.2                                                             1                   0Bps / 26Bps                  
  1.1.1.1                                                             1                   0Bps / 22Bps                  
- 3.3.3.3                                                             1                   0Bps / 22Bps                  
  4.4.4.4                                                             1                   0Bps / 21Bps                  
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_full_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_full_height.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                     
+ Total Up / Down: 0Bps / 0Bps                                                                                          
 ┌Utilization by process name──────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                               Connections               Rate Up / Down                       │
+│Process                                               Connections               Up / Down                            │
 │                                                                                                                     │
 │                                                                                                                     │
 │                                                                                                                     │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                                                     │
 └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by remote address────────────────────────────────────────────────────────────────────────────────────────┐
-│Remote Address                                                      Connections         Rate Up / Down               │
+│Remote Address                                                      Connections         Up / Down                    │
 │                                                                                                                     │
 │                                                                                                                     │
 │                                                                                                                     │

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
@@ -2,13 +2,13 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              92Bps                                                                                    
+                         92Bps                                                                                         
                                                                                                                        
                                                                                                                        
                                                                                                                        
  4                                                     1                         0Bps / 26Bps                          
- 1                                                     1                         0Bps / 22Bps                          
  5                                                     1                         0Bps / 22Bps                          
+ 1                                                     1                         0Bps / 22Bps                          
  2                                                     1                         0Bps / 21Bps                          
                                                                                                                        
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height-2.snap
@@ -2,12 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                         92Bps                                                                                         
+                         98Bps                                                                                         
                                                                                                                        
                                                                                                                        
                                                                                                                        
+ 5                                                     1                         0Bps / 28Bps                          
  4                                                     1                         0Bps / 26Bps                          
- 5                                                     1                         0Bps / 22Bps                          
  1                                                     1                         0Bps / 22Bps                          
  2                                                     1                         0Bps / 21Bps                          
                                                                                                                        

--- a/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_120_width_under_30_height.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                     
+ Total Up / Down: 0Bps / 0Bps                                                                                          
 ┌Utilization by process name──────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                               Connections               Rate Up / Down                       │
+│Process                                               Connections               Up / Down                            │
 │                                                                                                                     │
 │                                                                                                                     │
 │                                                                                                                     │

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              47Bps                                                                                                                                                           
+                         47Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/ui__multiple_connections_from_remote_address.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              41Bps                                                                                                                                                           
+                         41Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_different_connections.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              45Bps                                                                                                                                                           
+                         45Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection.snap
+++ b/src/tests/cases/snapshots/ui__multiple_packets_of_traffic_from_single_connection.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
@@ -2,12 +2,12 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                         92Bps                                                                                                                                                                
+                         98Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+ 5                           1                           0Bps / 28Bps                           3.3.3.3                                 1                     0Bps / 28Bps                    
  4                           1                           0Bps / 26Bps                           2.2.2.2                                 1                     0Bps / 26Bps                    
- 5                           1                           0Bps / 22Bps                           3.3.3.3                                 1                     0Bps / 22Bps                    
  1                           1                           0Bps / 22Bps                           1.1.1.1                                 1                     0Bps / 22Bps                    
  2                           1                           0Bps / 21Bps                           4.4.4.4                                 1                     0Bps / 21Bps                    
                                                                                                                                                                                               
@@ -30,8 +30,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
+ <interface_name>:4435 => 3.3.3.3:1337 (tcp)                                                                           5                             0Bps / 28Bps                             
  <interface_name>:4434 => 2.2.2.2:54321 (tcp)                                                                          4                             0Bps / 26Bps                             
- <interface_name>:4435 => 3.3.3.3:1337 (tcp)                                                                           5                             0Bps / 22Bps                             
  <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             0Bps / 22Bps                             
  <interface_name>:4432 => 4.4.4.4:1337 (tcp)                                                                           2                             0Bps / 21Bps                             
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections-2.snap
@@ -2,13 +2,13 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              92Bps                                                                                                                                                           
+                         92Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
  4                           1                           0Bps / 26Bps                           2.2.2.2                                 1                     0Bps / 26Bps                    
- 1                           1                           0Bps / 22Bps                           1.1.1.1                                 1                     0Bps / 22Bps                    
  5                           1                           0Bps / 22Bps                           3.3.3.3                                 1                     0Bps / 22Bps                    
+ 1                           1                           0Bps / 22Bps                           1.1.1.1                                 1                     0Bps / 22Bps                    
  2                           1                           0Bps / 21Bps                           4.4.4.4                                 1                     0Bps / 21Bps                    
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -31,8 +31,8 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
  <interface_name>:4434 => 2.2.2.2:54321 (tcp)                                                                          4                             0Bps / 26Bps                             
- <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             0Bps / 22Bps                             
  <interface_name>:4435 => 3.3.3.3:1337 (tcp)                                                                           5                             0Bps / 22Bps                             
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             0Bps / 22Bps                             
  <interface_name>:4432 => 4.4.4.4:1337 (tcp)                                                                           2                             0Bps / 21Bps                             
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/ui__multiple_processes_with_multiple_connections.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       53      60                                                                                                                                                             
+                  53      60                                                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/ui__no_resolve_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       45Bps / 49Bps                                                                                                                                                          
+                  45Bps / 49Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       21Bps / 0Bps                                                                                                                                                           
+                  21Bps / 0Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/ui__one_packet_of_traffic.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              46Bps                                                                                                                                                           
+                         46Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/ui__one_process_with_multiple_connections.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__pause_by_space-2.snap
+++ b/src/tests/cases/snapshots/ui__pause_by_space-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps [PAUSED]                                                                                                                                                   
+ Total Up / Down: 0Bps / 0Bps [PAUSED]                                                                                                                                                        
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__pause_by_space.snap
+++ b/src/tests/cases/snapshots/ui__pause_by_space.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                              65                                                                                                                                                              
+                         65                                                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              41Bps                                                                                                                                                           
+                         41Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       53      60                                                                                                                                                             
+                  53      60                                                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       45Bps / 49Bps                                                                                                                                                          
+                  45Bps / 49Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional_total-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional_total-2.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/cases/ui.rs
+expression: "&terminal_draw_events_mirror[2]"
+---
+                  98    109B                                                                                                                                                                  
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                         59    62                                                                                             59    62                        
+                                                         39    45                                                                                             39    45                        
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                     59    62                                 
+                                                                                                                                                     39    45                                 
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional_total.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_bi_directional_total.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/cases/ui.rs
+expression: "&terminal_draw_events_mirror[1]"
+---
+                  45B / 49B                                                                                                                                                                   
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ 1                           1                           28B / 30B                              1.1.1.1                                 1                     28B / 30B                       
+ 5                           1                           17B / 18B                              3.3.3.3                                 1                     17B / 18B                       
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             28B / 30B                                
+ <interface_name>:4435 => 3.3.3.3:1337 (tcp)                                                                           5                             17B / 18B                                
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_total-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_total-2.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/cases/ui.rs
+expression: "&terminal_draw_events_mirror[2]"
+---
+                       106B                                                                                                                                                                   
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                              57                                                                                                   57                         
+                                                              4                                                                                                    4                          
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                          57                                  
+                                                                                                                                                          4                                   
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_total.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_multiple_processes_total.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/cases/ui.rs
+expression: "&terminal_draw_events_mirror[1]"
+---
+                       41B                                                                                                                                                                    
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ 1                           1                           0B / 22B                               1.1.1.1                                 1                     0B / 22B                        
+ 5                           1                           0B / 19B                               3.3.3.3                                 1                     0B / 19B                        
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             0B / 22B                                 
+ <interface_name>:4435 => 3.3.3.3:1337 (tcp)                                                                           5                             0B / 19B                                 
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                              31                                                                                                                                                              
+                         31                                                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                              22Bps                                                                                                                                                           
+                         22Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process_total-2.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process_total-2.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/cases/ui.rs
+expression: "&terminal_draw_events_mirror[2]"
+---
+                       53                                                                                                                                                                     
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                              53                                                                                                   53                         
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                          53                                  
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+

--- a/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process_total.snap
+++ b/src/tests/cases/snapshots/ui__sustained_traffic_from_one_process_total.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/cases/ui.rs
+expression: "&terminal_draw_events_mirror[1]"
+---
+                       22B                                                                                                                                                                    
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ 1                           1                           0B / 22B                               1.1.1.1                                 1                     0B / 22B                        
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             0B / 22B                                 
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       53      60                                                                                                                                                             
+                  53      60                                                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_host_names.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       45Bps / 49Bps                                                                                                                                                          
+                  45Bps / 49Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       21Bps / 0Bps                                                                                                                                                           
+                  21Bps / 0Bps                                                                                                                                                                
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
-│Process                     Connections                 Rate Up / Down                       ││Remote Address                          Connections           Rate Up / Down                 │
+│Process                     Connections                 Up / Down                            ││Remote Address                          Connections           Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                                                             ││                                                                                             │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__truncate_long_hostnames-2.snap
+++ b/src/tests/cases/snapshots/ui__truncate_long_hostnames-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                       53      60                                                                                                                                                             
+                  53      60                                                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__truncate_long_hostnames.snap
+++ b/src/tests/cases/snapshots/ui__truncate_long_hostnames.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       45Bps / 49Bps                                                                                                                                                          
+                  45Bps / 49Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__two_packets_only_addresses-2.snap
+++ b/src/tests/cases/snapshots/ui__two_packets_only_addresses-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       24Bps / 25Bps                                                                                                                                                          
+                  24Bps / 25Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__two_packets_only_addresses.snap
+++ b/src/tests/cases/snapshots/ui__two_packets_only_addresses.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by remote address───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Remote Address                                                                                                        Connections                   Rate Up / Down                          │
+│Remote Address                                                                                                        Connections                   Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__two_packets_only_connections-2.snap
+++ b/src/tests/cases/snapshots/ui__two_packets_only_connections-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       24Bps / 25Bps                                                                                                                                                          
+                  24Bps / 25Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__two_packets_only_connections.snap
+++ b/src/tests/cases/snapshots/ui__two_packets_only_connections.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Connection                                                                                                            Process                       Rate Up / Down                          │
+│Connection                                                                                                            Process                       Up / Down                               │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__two_packets_only_processes-2.snap
+++ b/src/tests/cases/snapshots/ui__two_packets_only_processes-2.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
-                       24Bps / 25Bps                                                                                                                                                          
+                  24Bps / 25Bps                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__two_packets_only_processes.snap
+++ b/src/tests/cases/snapshots/ui__two_packets_only_processes.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by process name─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Process                                                                       Connections                                       Rate Up / Down                                              │
+│Process                                                                       Connections                                       Up / Down                                                   │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/ui__two_windows_split_horizontally.snap
+++ b/src/tests/cases/snapshots/ui__two_windows_split_horizontally.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                          
+ Total Up / Down: 0Bps / 0Bps                               
 ┌Utilization by remote address─────────────────────────────┐
-│Remote Address          Rate Up / Down                    │
+│Remote Address          Up / Down                         │
 │                                                          │
 │                                                          │
 │                                                          │
@@ -28,7 +28,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                                          │
 └──────────────────────────────────────────────────────────┘
 ┌Utilization by connection─────────────────────────────────┐
-│Connection                  Rate Up / Down                │
+│Connection                  Up / Down                     │
 │                                                          │
 │                                                          │
 │                                                          │

--- a/src/tests/cases/snapshots/ui__two_windows_split_vertically.snap
+++ b/src/tests/cases/snapshots/ui__two_windows_split_vertically.snap
@@ -2,9 +2,9 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[0]"
 ---
- Total Rate Up / Down: 0Bps / 0Bps                                                                                                                                                            
+ Total Up / Down: 0Bps / 0Bps                                                                                                                                                                 
 ┌Utilization by remote address────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
-│Remote Address                          Connections           Rate Up / Down                 ││Connection                              Process               Rate Up / Down                 │
+│Remote Address                          Connections           Up / Down                      ││Connection                              Process               Up / Down                      │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -146,6 +146,7 @@ fn opts_factory(raw: bool) -> Opt {
             addresses: false,
             connections: false,
             processes: false,
+            total: false,
         },
     }
 }

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -146,7 +146,7 @@ fn opts_factory(raw: bool) -> Opt {
             addresses: false,
             connections: false,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     }
 }

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -733,7 +733,6 @@ fn sustained_traffic_from_multiple_processes_total() {
     assert_snapshot!(&terminal_draw_events_mirror[2]);
 }
 
-
 #[test]
 fn sustained_traffic_from_multiple_processes_bi_directional() {
     let network_frames = vec![NetworkFrames::new(vec![

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -468,7 +468,7 @@ fn multiple_processes_with_multiple_connections() {
             "10.0.0.2",
             1337,
             4435,
-            b"Awesome, I'm from 3.3.3.3",
+            b"Greetings traveller, I'm from 3.3.3.3",
         )),
         Some(build_tcp_packet(
             "2.2.2.2",
@@ -1105,7 +1105,7 @@ fn layout_full_width_under_30_height() {
             "10.0.0.2",
             1337,
             4435,
-            b"Awesome, I'm from 3.3.3.3",
+            b"Greetings traveller, I'm from 3.3.3.3",
         )),
         Some(build_tcp_packet(
             "2.2.2.2",
@@ -1158,7 +1158,7 @@ fn layout_under_120_width_full_height() {
             "10.0.0.2",
             1337,
             4435,
-            b"Awesome, I'm from 3.3.3.3",
+            b"Greetings traveller, I'm from 3.3.3.3",
         )),
         Some(build_tcp_packet(
             "2.2.2.2",
@@ -1210,7 +1210,7 @@ fn layout_under_120_width_under_30_height() {
             "10.0.0.2",
             1337,
             4435,
-            b"Awesome, I'm from 3.3.3.3",
+            b"Greetings traveller, I'm from 3.3.3.3",
         )),
         Some(build_tcp_packet(
             "2.2.2.2",

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -584,6 +584,47 @@ fn sustained_traffic_from_one_process() {
 }
 
 #[test]
+fn sustained_traffic_from_one_process_total() {
+    let network_frames = vec![NetworkFrames::new(vec![
+        Some(build_tcp_packet(
+            "1.1.1.1",
+            "10.0.0.2",
+            12345,
+            443,
+            b"I have come from 1.1.1.1",
+        )),
+        None, // sleep
+        Some(build_tcp_packet(
+            "1.1.1.1",
+            "10.0.0.2",
+            12345,
+            443,
+            b"Same here, but one second later",
+        )),
+    ]) as Box<dyn DataLinkReceiver>];
+
+    let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
+
+    let os_input = os_input_output(network_frames, 3);
+    let mut opts = opts_ui();
+    opts.render_opts.total_utilization = true;
+    start(backend, os_input, opts);
+    let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
+
+    let expected_terminal_events = vec![
+        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+    ];
+    assert_eq!(
+        &terminal_events.lock().unwrap()[..],
+        &expected_terminal_events[..]
+    );
+
+    assert_eq!(terminal_draw_events_mirror.len(), 3);
+    assert_snapshot!(&terminal_draw_events_mirror[1]);
+    assert_snapshot!(&terminal_draw_events_mirror[2]);
+}
+
+#[test]
 fn sustained_traffic_from_multiple_processes() {
     let network_frames = vec![NetworkFrames::new(vec![
         Some(build_tcp_packet(
@@ -636,6 +677,62 @@ fn sustained_traffic_from_multiple_processes() {
     assert_snapshot!(&terminal_draw_events_mirror[1]);
     assert_snapshot!(&terminal_draw_events_mirror[2]);
 }
+
+#[test]
+fn sustained_traffic_from_multiple_processes_total() {
+    let network_frames = vec![NetworkFrames::new(vec![
+        Some(build_tcp_packet(
+            "1.1.1.1",
+            "10.0.0.2",
+            12345,
+            443,
+            b"I have come from 1.1.1.1",
+        )),
+        Some(build_tcp_packet(
+            "3.3.3.3",
+            "10.0.0.2",
+            1337,
+            4435,
+            b"I come from 3.3.3.3",
+        )),
+        None, // sleep
+        Some(build_tcp_packet(
+            "1.1.1.1",
+            "10.0.0.2",
+            12345,
+            443,
+            b"I have come from 1.1.1.1 one second later",
+        )),
+        Some(build_tcp_packet(
+            "3.3.3.3",
+            "10.0.0.2",
+            1337,
+            4435,
+            b"I come 3.3.3.3 one second later",
+        )),
+    ]) as Box<dyn DataLinkReceiver>];
+
+    let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
+
+    let os_input = os_input_output(network_frames, 3);
+    let mut opts = opts_ui();
+    opts.render_opts.total_utilization = true;
+    start(backend, os_input, opts);
+    let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
+
+    let expected_terminal_events = vec![
+        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+    ];
+    assert_eq!(
+        &terminal_events.lock().unwrap()[..],
+        &expected_terminal_events[..]
+    );
+
+    assert_eq!(terminal_draw_events_mirror.len(), 3);
+    assert_snapshot!(&terminal_draw_events_mirror[1]);
+    assert_snapshot!(&terminal_draw_events_mirror[2]);
+}
+
 
 #[test]
 fn sustained_traffic_from_multiple_processes_bi_directional() {
@@ -703,6 +800,89 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
 
     let os_input = os_input_output(network_frames, 3);
     let opts = opts_ui();
+    start(backend, os_input, opts);
+    let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
+
+    let expected_terminal_events = vec![
+        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+    ];
+    assert_eq!(
+        &terminal_events.lock().unwrap()[..],
+        &expected_terminal_events[..]
+    );
+
+    assert_eq!(terminal_draw_events_mirror.len(), 3);
+    assert_snapshot!(&terminal_draw_events_mirror[1]);
+    assert_snapshot!(&terminal_draw_events_mirror[2]);
+}
+
+#[test]
+fn sustained_traffic_from_multiple_processes_bi_directional_total() {
+    let network_frames = vec![NetworkFrames::new(vec![
+        Some(build_tcp_packet(
+            "10.0.0.2",
+            "3.3.3.3",
+            4435,
+            1337,
+            b"omw to 3.3.3.3",
+        )),
+        Some(build_tcp_packet(
+            "3.3.3.3",
+            "10.0.0.2",
+            1337,
+            4435,
+            b"I was just there!",
+        )),
+        Some(build_tcp_packet(
+            "1.1.1.1",
+            "10.0.0.2",
+            12345,
+            443,
+            b"Is it nice there? I think 1.1.1.1 is dull",
+        )),
+        Some(build_tcp_packet(
+            "10.0.0.2",
+            "1.1.1.1",
+            443,
+            12345,
+            b"Well, I heard 1.1.1.1 is all the rage",
+        )),
+        None, // sleep
+        Some(build_tcp_packet(
+            "10.0.0.2",
+            "3.3.3.3",
+            4435,
+            1337,
+            b"Wait for me!",
+        )),
+        Some(build_tcp_packet(
+            "3.3.3.3",
+            "10.0.0.2",
+            1337,
+            4435,
+            b"They're waiting for you...",
+        )),
+        Some(build_tcp_packet(
+            "1.1.1.1",
+            "10.0.0.2",
+            12345,
+            443,
+            b"1.1.1.1 forever!",
+        )),
+        Some(build_tcp_packet(
+            "10.0.0.2",
+            "1.1.1.1",
+            443,
+            12345,
+            b"10.0.0.2 forever!",
+        )),
+    ]) as Box<dyn DataLinkReceiver>];
+
+    let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
+
+    let os_input = os_input_output(network_frames, 3);
+    let mut opts = opts_ui();
+    opts.render_opts.total_utilization = true;
     start(backend, os_input, opts);
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -107,7 +107,7 @@ fn basic_only_processes() {
             addresses: false,
             connections: false,
             processes: true,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -132,7 +132,7 @@ fn basic_only_connections() {
             addresses: false,
             connections: true,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -157,7 +157,7 @@ fn basic_only_addresses() {
             addresses: true,
             connections: false,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -180,7 +180,7 @@ fn two_packets_only_processes() {
             addresses: false,
             connections: false,
             processes: true,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -204,7 +204,7 @@ fn two_packets_only_connections() {
             addresses: false,
             connections: true,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -228,7 +228,7 @@ fn two_packets_only_addresses() {
             addresses: true,
             connections: false,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -254,7 +254,7 @@ fn two_windows_split_horizontally() {
             addresses: true,
             connections: true,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
 
@@ -279,7 +279,7 @@ fn two_windows_split_vertically() {
             addresses: true,
             connections: true,
             processes: false,
-            total: false,
+            total_utilization: false,
         },
     };
 

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -107,6 +107,7 @@ fn basic_only_processes() {
             addresses: false,
             connections: false,
             processes: true,
+            total: false,
         },
     };
 
@@ -131,6 +132,7 @@ fn basic_only_connections() {
             addresses: false,
             connections: true,
             processes: false,
+            total: false,
         },
     };
 
@@ -155,6 +157,7 @@ fn basic_only_addresses() {
             addresses: true,
             connections: false,
             processes: false,
+            total: false,
         },
     };
 
@@ -177,6 +180,7 @@ fn two_packets_only_processes() {
             addresses: false,
             connections: false,
             processes: true,
+            total: false,
         },
     };
 
@@ -200,6 +204,7 @@ fn two_packets_only_connections() {
             addresses: false,
             connections: true,
             processes: false,
+            total: false,
         },
     };
 
@@ -223,6 +228,7 @@ fn two_packets_only_addresses() {
             addresses: true,
             connections: false,
             processes: false,
+            total: false,
         },
     };
 
@@ -248,6 +254,7 @@ fn two_windows_split_horizontally() {
             addresses: true,
             connections: true,
             processes: false,
+            total: false,
         },
     };
 
@@ -272,6 +279,7 @@ fn two_windows_split_vertically() {
             addresses: true,
             connections: true,
             processes: false,
+            total: false,
         },
     };
 


### PR DESCRIPTION
Closes #147 

This works pretty well, but the existing code wasn't really designed for accumulated usage like this, so I've left in some comments where I'd appreciate some others' opinions on refactoring matters.

This feature really adds a lot to `bandwhich` for me! I have a metered connection on a server and this PR makes it possible to track down what processes use the most data over a longer period of time!

This is a draft PR at the moment and I'd be hesitant to merge before we have the chance to address some of the comments I left behind :)

Additionally, the test snapshots have not been updated yet. 