### PR TITLE
Migrate to pcap on the datalink layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ipnetwork 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pcap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_base_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pnet_sys_bandwhich_fork 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1914,6 +1923,7 @@ dependencies = [
 "checksum packet-builder 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3a4c42f976f5e39b18002d165d238fadb0a897e1252cf96e39109f515e85aa8"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum pcap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f912b9e56d1d4851a5175c118fc6503c9f69a8fe1a0649a51aff20b92c757491"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e4fb201c5c22a55d8b24fef95f78be52738e5e1361129be1b5e862ecdb6894a"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "MIT"
 exclude = ["src/tests/*", "demo.gif"]
 
 [dependencies]
-pnet_bandwhich_fork = "0.23.1"
 ipnetwork = "0.15.0"
 tui = "0.5"
 termion = "1.5"
@@ -31,6 +30,10 @@ lazy_static = "1.4.0"
 tokio = { version = "0.2", features = ["rt-core", "sync"] }
 trust-dns-resolver = "0.18.1"
 async-trait = "0.1.21"
+
+[dependencies.pnet_bandwhich_fork]
+version = "0.23.1"
+features = ["pcap"]
 
 [target.'cfg(target_os="linux")'.dependencies]
 procfs = "0.7.4"

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -1,7 +1,7 @@
+use ::pnet_bandwhich_fork::datalink::pcap::Config;
 use ::pnet_bandwhich_fork::datalink::Channel::Ethernet;
 use ::pnet_bandwhich_fork::datalink::DataLinkReceiver;
 use ::pnet_bandwhich_fork::datalink::{self, NetworkInterface};
-use ::pnet_bandwhich_fork::datalink::pcap::Config;
 use ::std::io::{self, stdin, ErrorKind, Write};
 use ::termion::event::Event;
 use ::termion::input::TermRead;

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -1,6 +1,7 @@
 use ::pnet_bandwhich_fork::datalink::Channel::Ethernet;
 use ::pnet_bandwhich_fork::datalink::DataLinkReceiver;
-use ::pnet_bandwhich_fork::datalink::{self, Config, NetworkInterface};
+use ::pnet_bandwhich_fork::datalink::{self, NetworkInterface};
+use ::pnet_bandwhich_fork::datalink::pcap::Config;
 use ::std::io::{self, stdin, ErrorKind, Write};
 use ::termion::event::Event;
 use ::termion::input::TermRead;
@@ -38,7 +39,7 @@ fn get_datalink_channel(
     let mut config = Config::default();
     config.read_timeout = Some(time::Duration::new(1, 0));
 
-    match datalink::channel(interface, config) {
+    match datalink::pcap::channel(interface, config) {
         Ok(Ethernet(_tx, rx)) => Ok(rx),
         Ok(_) => Err(GetInterfaceErrorKind::OtherError(format!(
             "{}: Unsupported interface type",


### PR DESCRIPTION
Fixes (probably) #136

There were some wild bugs lurking here... As it turns out, my problem (and I suspect the problem others have been having) is related to a relatively obscure and poorly documented hardware feature of modern network cards: offloading. In my particular case, generic receive offload (gro) is what led to [netmap](https://github.com/luigirizzo/netmap/issues/268) (a backend of the pnet backend of Bandwhich) dropping packets for being too large (because gro merges many packets before passing them to the operating system).

The first solution was turning off this feature and related "offload" features using `ethtool`:
```bash
# ethtool -K eth0 tx off rx off gso off tso off gro off lro off
```

Obviously though, that's a hacky workaround and other programs are able to read these packets correctly! As it turns out, pnet has many available backends, so I gave a couple a try. Unfortunately the `linux` backend had the same issue as `netmap`, but luckily, the `pcap` backend could gracefully handle these merged packets!

I needed to enable the `pcap` feature of `pnet`, but now things are reporting correctly for both upload and download (for me at least)!