### PR TITLE
Fix the loss of large, merged packets

### DIFF
--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -37,6 +37,7 @@ fn get_datalink_channel(
 ) -> Result<Box<dyn DataLinkReceiver>, GetInterfaceErrorKind> {
     let mut config = Config::default();
     config.read_timeout = Some(time::Duration::new(1, 0));
+    config.read_buffer_size = 65536;
 
     match datalink::channel(interface, config) {
         Ok(Ethernet(_tx, rx)) => Ok(rx),


### PR DESCRIPTION
A good thing I took a second look at this. Just bumping the read_buffer_size to the max allowed by the kernel solves the problem. One line in one file!

Wild how it can make so much of a difference...

Here is the current (master) bandwhich on the left, wget in the middle, and this patched version on the left: https://imgur.com/HmDyaOe