### PR TITLE
Add terabytes as a display unit

### DIFF
--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -8,7 +8,9 @@ pub struct DisplayBandwidth {
 impl fmt::Display for DisplayBandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let suffix = if self.as_rate { "ps" } else { "" };
-        if self.bandwidth > 999_999_999.0 {
+        if self.bandwidth > 999_999_999_999.0 {
+            write!(f, "{:.2}TB{}", self.bandwidth / 1_000_000_000_000.0, suffix)
+        } else if self.bandwidth > 999_999_999.0 {
             write!(f, "{:.2}GB{}", self.bandwidth / 1_000_000_000.0, suffix)
         } else if self.bandwidth > 999_999.0 {
             write!(f, "{:.2}MB{}", self.bandwidth / 1_000_000.0, suffix)


### PR DESCRIPTION
Pretty small, 3 line tweak. Just adds TB as a unit for bandwidth. Obviously not a concern for rate-mode for a while, but I'm accumulated amounts can creep up above a terabyte over time:
![Screenshot from 2020-05-08 11-40-31](https://user-images.githubusercontent.com/6251883/81398438-1fb31600-9121-11ea-86a7-4590a439da0a.png)
