### PR TITLE
Add delimiters to raw output

### DIFF
--- a/src/tests/cases/snapshots/raw_mode__bi_directional_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__bi_directional_traffic.snap
@@ -2,7 +2,12 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 24/25 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 24/25 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 24/25 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_connections_from_remote_address.snap
@@ -2,8 +2,13 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/47 connections: 2
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/25 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/47 connections: 2
+
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_different_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_different_connections.snap
@@ -2,9 +2,14 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
 process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/19 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 2.2.2.2:12345 (tcp) up/down Bps: 0/22 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4434 => 2.2.2.2:54321 (tcp) up/down Bps: 0/19 process: "4"
 remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/41 connections: 2
+
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_single_connection.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_packets_of_traffic_from_single_connection.snap
@@ -2,7 +2,12 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/45 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/45 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/45 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__multiple_processes_with_multiple_connections.snap
@@ -2,6 +2,10 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/28 connections: 1
 process: <TIMESTAMP_REMOVED> "4" up/down Bps: 0/26 connections: 1
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
@@ -14,4 +18,5 @@ remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/28 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 2.2.2.2 up/down Bps: 0/26 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 4.4.4.4 up/down Bps: 0/21 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/raw_mode__no_resolve_mode.snap
@@ -2,16 +2,23 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 28/30 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 17/18 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 28/30 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 17/18 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 28/30 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 17/18 connections: 1
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 31/32 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 22/27 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__one_ip_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_ip_packet_of_traffic.snap
@@ -2,7 +2,12 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 21/0 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 21/0 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 21/0 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__one_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_packet_of_traffic.snap
@@ -2,7 +2,12 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 21/0 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 21/0 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 21/0 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/raw_mode__one_process_with_multiple_connections.snap
@@ -2,8 +2,13 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/46 connections: 2
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12346 (tcp) up/down Bps: 0/24 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/46 connections: 2
+
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes.snap
@@ -2,16 +2,23 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/19 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/19 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/19 connections: 1
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/35 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 0/30 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/35 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 0/30 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/35 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 0/30 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -2,16 +2,23 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 28/30 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 17/18 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 28/30 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 17/18 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 28/30 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 17/18 connections: 1
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 31/32 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => 3.3.3.3:1337 (tcp) up/down Bps: 22/27 process: "5"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 31/32 connections: 1
 remote_address: <TIMESTAMP_REMOVED> 3.3.3.3 up/down Bps: 22/27 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/raw_mode__sustained_traffic_from_one_process.snap
@@ -2,10 +2,17 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/22 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/22 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/22 connections: 1
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 0/31 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => 1.1.1.1:12345 (tcp) up/down Bps: 0/31 process: "1"
 remote_address: <TIMESTAMP_REMOVED> 1.1.1.1 up/down Bps: 0/31 connections: 1
+
 

--- a/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/raw_mode__traffic_with_host_names.snap
@@ -2,16 +2,23 @@
 source: src/tests/cases/raw_mode.rs
 expression: formatted
 ---
+Refreshing:
+<NO TRAFFIC>
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 28/30 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 17/18 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 28/30 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 17/18 process: "5"
 remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 28/30 connections: 1
 remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 17/18 connections: 1
+
+Refreshing:
 process: <TIMESTAMP_REMOVED> "1" up/down Bps: 31/32 connections: 1
 process: <TIMESTAMP_REMOVED> "5" up/down Bps: 22/27 connections: 1
 connection: <TIMESTAMP_REMOVED> <interface_name>:443 => one.one.one.one:12345 (tcp) up/down Bps: 31/32 process: "1"
 connection: <TIMESTAMP_REMOVED> <interface_name>:4435 => three.three.three.three:1337 (tcp) up/down Bps: 22/27 process: "5"
 remote_address: <TIMESTAMP_REMOVED> one.one.one.one up/down Bps: 31/32 connections: 1
 remote_address: <TIMESTAMP_REMOVED> three.three.three.three up/down Bps: 22/27 connections: 1
+
 


### PR DESCRIPTION
This is useful for external programs that wants to parse the output.
Without a delimiter like its currently the case, its impossible (as far as I know) to parse it correctly.
Also visually it looks more organized.