### PR TITLE
fix(formatting): improve accuracy

### DIFF
--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -10,7 +10,12 @@ impl fmt::Display for DisplayBandwidth {
         let suffix = if self.as_rate { "ps" } else { "" };
         if self.bandwidth > 999_999_999_999.0 {
             // 1024 * 1024 * 1024 * 1024
-            write!(f, "{:.2}TiB{}", self.bandwidth / 1_099_511_627_776.0, suffix)
+            write!(
+                f,
+                "{:.2}TiB{}",
+                self.bandwidth / 1_099_511_627_776.0,
+                suffix
+            )
         } else if self.bandwidth > 999_999_999.0 {
             write!(f, "{:.2}GiB{}", self.bandwidth / 1_073_741_824.0, suffix) // 1024 * 1024 * 1024
         } else if self.bandwidth > 999_999.0 {

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -9,7 +9,8 @@ impl fmt::Display for DisplayBandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let suffix = if self.as_rate { "ps" } else { "" };
         if self.bandwidth > 999_999_999_999.0 {
-            write!(f, "{:.2}TB{}", self.bandwidth / 1_099_511_627_776.0, suffix) // 1024 * 1024 * 1024 * 1024
+            // 1024 * 1024 * 1024 * 1024
+            write!(f, "{:.2}TB{}", self.bandwidth / 1_099_511_627_776.0, suffix)
         } else if self.bandwidth > 999_999_999.0 {
             write!(f, "{:.2}GB{}", self.bandwidth / 1_073_741_824.0, suffix) // 1024 * 1024 * 1024
         } else if self.bandwidth > 999_999.0 {

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -9,13 +9,13 @@ impl fmt::Display for DisplayBandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let suffix = if self.as_rate { "ps" } else { "" };
         if self.bandwidth > 999_999_999_999.0 {
-            write!(f, "{:.2}TB{}", self.bandwidth / 1_000_000_000_000.0, suffix)
+            write!(f, "{:.2}TB{}", self.bandwidth / 1_099_511_627_776.0, suffix) // 1024 * 1024 * 1024 * 1024
         } else if self.bandwidth > 999_999_999.0 {
-            write!(f, "{:.2}GB{}", self.bandwidth / 1_000_000_000.0, suffix)
+            write!(f, "{:.2}GB{}", self.bandwidth / 1_073_741_824.0, suffix) // 1024 * 1024 * 1024
         } else if self.bandwidth > 999_999.0 {
-            write!(f, "{:.2}MB{}", self.bandwidth / 1_000_000.0, suffix)
+            write!(f, "{:.2}MB{}", self.bandwidth / 1_048_576.0, suffix) //  1024 * 1024
         } else if self.bandwidth > 999.0 {
-            write!(f, "{:.2}KB{}", self.bandwidth / 1000.0, suffix)
+            write!(f, "{:.2}KB{}", self.bandwidth / 1024.0, suffix)
         } else {
             write!(f, "{}B{}", self.bandwidth, suffix)
         }

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -10,13 +10,13 @@ impl fmt::Display for DisplayBandwidth {
         let suffix = if self.as_rate { "ps" } else { "" };
         if self.bandwidth > 999_999_999_999.0 {
             // 1024 * 1024 * 1024 * 1024
-            write!(f, "{:.2}TB{}", self.bandwidth / 1_099_511_627_776.0, suffix)
+            write!(f, "{:.2}TiB{}", self.bandwidth / 1_099_511_627_776.0, suffix)
         } else if self.bandwidth > 999_999_999.0 {
-            write!(f, "{:.2}GB{}", self.bandwidth / 1_073_741_824.0, suffix) // 1024 * 1024 * 1024
+            write!(f, "{:.2}GiB{}", self.bandwidth / 1_073_741_824.0, suffix) // 1024 * 1024 * 1024
         } else if self.bandwidth > 999_999.0 {
-            write!(f, "{:.2}MB{}", self.bandwidth / 1_048_576.0, suffix) //  1024 * 1024
+            write!(f, "{:.2}MiB{}", self.bandwidth / 1_048_576.0, suffix) //  1024 * 1024
         } else if self.bandwidth > 999.0 {
-            write!(f, "{:.2}KB{}", self.bandwidth / 1024.0, suffix)
+            write!(f, "{:.2}KiB{}", self.bandwidth / 1024.0, suffix)
         } else {
             write!(f, "{}B{}", self.bandwidth, suffix)
         }


### PR DESCRIPTION
This fix improves the accuracy presentation by dividing the bytes per second by the right divisions (eg. `1_048_576` instead of `1_000_000` for MB).