### PR TITLE
feat(ui): crossplatform terminal resize handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,6 @@ dependencies = [
  "procfs 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.3 (git+https://github.com/tailhook/resolv-conf?rev=83c0f25ebcb0615550488692c5213ca1ae4acd8f)",
- "signal-hook 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sysinfo 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ ipnetwork = "0.16.0"
 tui = { version = "0.5", default-features = false, features = ["crossterm"]}
 crossterm = "0.17.7"
 structopt = "0.3"
-signal-hook = "0.1.10"
 failure = "0.1.6"
 chrono = "0.4"
 regex = "1.3.1"

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-2.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-2.snap
@@ -2,6 +2,11 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[1]"
 ---
+                  21Bps / 0Bps                                                                                                                                                                
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+ 1                           1                           21Bps / 0Bps                           1.1.1.1                                 1                     21Bps / 0Bps                    
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -25,12 +30,7 @@ expression: "&terminal_draw_events_mirror[1]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
+ <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             21Bps / 0Bps                             
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
+++ b/src/tests/cases/snapshots/ui__traffic_with_winch_event-3.snap
@@ -2,11 +2,6 @@
 source: src/tests/cases/ui.rs
 expression: "&terminal_draw_events_mirror[2]"
 ---
-                  21Bps / 0Bps                                                                                                                                                                
-                                                                                                                                                                                              
-                                                                                                                                                                                              
-                                                                                                                                                                                              
- 1                           1                           21Bps / 0Bps                           1.1.1.1                                 1                     21Bps / 0Bps                    
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
@@ -30,7 +25,12 @@ expression: "&terminal_draw_events_mirror[2]"
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               
- <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                           1                             21Bps / 0Bps                             
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
+                                                                                                                                                                                              
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -1,6 +1,6 @@
 use crate::tests::fakes::TerminalEvent::*;
 use crate::tests::fakes::{
-    create_fake_dns_client, create_fake_on_winch, get_interfaces, get_open_sockets, NetworkFrames,
+    create_fake_dns_client, get_interfaces, get_open_sockets, NetworkFrames,
 };
 
 use ::insta::assert_snapshot;
@@ -10,13 +10,13 @@ use ::std::net::IpAddr;
 
 use crate::tests::cases::test_utils::{
     build_tcp_packet, opts_ui, os_input_output, os_input_output_factory, sample_frames,
-    sleep_and_quit_events, test_backend_factory,
+    sleep_and_quit_events, sleep_resize_and_quit_events, test_backend_factory,
 };
 use ::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use pnet::datalink::DataLinkReceiver;
 use std::iter;
 
-use crate::tests::fakes::KeyboardEvents;
+use crate::tests::fakes::TerminalEvents;
 
 use crate::{start, Opt, OsInputOutput, RenderOpts};
 
@@ -81,7 +81,7 @@ fn pause_by_space() {
         code: KeyCode::Char('c'),
     })));
 
-    let events = Box::new(KeyboardEvents::new(events));
+    let events = Box::new(TerminalEvents::new(events));
     let os_input = os_input_output_factory(network_frames, None, None, events);
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
     let opts = opts_ui();
@@ -136,7 +136,7 @@ fn rearranged_by_tab() {
         code: KeyCode::Char('c'),
     })));
 
-    let events = Box::new(KeyboardEvents::new(events));
+    let events = Box::new(TerminalEvents::new(events));
     let os_input = os_input_output_factory(network_frames, None, None, events);
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
     let opts = opts_ui();
@@ -1077,18 +1077,14 @@ fn traffic_with_host_names() {
         String::from("i-like-cheese.com"),
     );
     let dns_client = create_fake_dns_client(ips_to_hostnames);
-    let on_winch = create_fake_on_winch(false);
-    let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
         network_interfaces: get_interfaces(),
         network_frames,
         get_open_sockets,
-        keyboard_events: sleep_and_quit_events(3),
+        terminal_events: sleep_and_quit_events(3),
         dns_client,
-        on_winch,
-        cleanup,
         write_to_stdout,
     };
     let opts = opts_ui();
@@ -1186,18 +1182,14 @@ fn truncate_long_hostnames() {
         String::from("i-like-cheese.com"),
     );
     let dns_client = create_fake_dns_client(ips_to_hostnames);
-    let on_winch = create_fake_on_winch(false);
-    let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
         network_interfaces: get_interfaces(),
         network_frames,
         get_open_sockets,
-        keyboard_events: sleep_and_quit_events(3),
+        terminal_events: sleep_and_quit_events(3),
         dns_client,
-        on_winch,
-        cleanup,
         write_to_stdout,
     };
     let opts = opts_ui();
@@ -1294,18 +1286,14 @@ fn no_resolve_mode() {
         String::from("i-like-cheese.com"),
     );
     let dns_client = None;
-    let on_winch = create_fake_on_winch(false);
-    let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
         network_interfaces: get_interfaces(),
         network_frames,
         get_open_sockets,
-        keyboard_events: sleep_and_quit_events(3),
+        terminal_events: sleep_and_quit_events(3),
         dns_client,
-        on_winch,
-        cleanup,
         write_to_stdout,
     };
     let opts = opts_ui();
@@ -1338,18 +1326,14 @@ fn traffic_with_winch_event() {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
     let dns_client = create_fake_dns_client(HashMap::new());
-    let on_winch = create_fake_on_winch(true);
-    let cleanup = Box::new(|| {});
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
         network_interfaces: get_interfaces(),
         network_frames,
         get_open_sockets,
-        keyboard_events: sleep_and_quit_events(2),
+        terminal_events: sleep_resize_and_quit_events(2),
         dns_client,
-        on_winch,
-        cleanup,
         write_to_stdout,
     };
     let opts = opts_ui();

--- a/src/tests/fakes/fake_input.rs
+++ b/src/tests/fakes/fake_input.rs
@@ -13,21 +13,20 @@ use crate::{
         dns::{self, Lookup},
         Connection, Protocol,
     },
-    os::OnSigWinch,
     OpenSockets,
 };
 
-pub struct KeyboardEvents {
+pub struct TerminalEvents {
     pub events: Vec<Option<Event>>,
 }
 
-impl KeyboardEvents {
+impl TerminalEvents {
     pub fn new(mut events: Vec<Option<Event>>) -> Self {
         events.reverse(); // this is so that we do not have to shift the array
-        KeyboardEvents { events }
+        TerminalEvents { events }
     }
 }
-impl Iterator for KeyboardEvents {
+impl Iterator for TerminalEvents {
     type Item = Event;
     fn next(&mut self) -> Option<Event> {
         match self.events.pop() {
@@ -155,15 +154,6 @@ pub fn get_interfaces() -> Vec<NetworkInterface> {
         // at offset 14
         flags: 0,
     }]
-}
-
-pub fn create_fake_on_winch(should_send_winch_event: bool) -> Box<OnSigWinch> {
-    Box::new(move |cb| {
-        if should_send_winch_event {
-            thread::sleep(time::Duration::from_millis(900));
-            cb()
-        }
-    })
 }
 
 pub fn create_fake_dns_client(ips_to_hosts: HashMap<IpAddr, String>) -> Option<dns::Client> {


### PR DESCRIPTION
I've found that crossterm emits Event::Resize which can be used instead of sigwinch, it also support Windows, so I refactored resizing logic to support all platforms.