### PR TITLE
fix(ui): upgrade tui to latest version and fix breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "sysinfo 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-resolver 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tui 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tui 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "tui"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2335,7 +2335,7 @@ dependencies = [
 "checksum tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e765bf9f550bd9b8a970633ca3b56b8120c4b6c5dcbe26a93744cb02fee4b17"
 "checksum trust-dns-proto 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "253a722ff22a1217b7af6199cb2ec5824a19c5110e0db21d3fcb28d5f6e1b0ee"
 "checksum trust-dns-resolver 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72d7df08b45f4d6d124cdae3c303f9908159a17b39e633e524349e91bc798d32"
-"checksum tui 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a977b0bb2e2033a6fef950f218f13622c3c34e59754b704ce3492dedab1dfe95"
+"checksum tui 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c2eaeee894a1e9b90f80aa466fe59154fdb471980b5e104d8836fcea309ae17e"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
  "sysinfo 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-resolver 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tui 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tui 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -370,19 +370,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_cursor 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_input 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_screen 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_style 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_terminal 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -393,77 +380,6 @@ dependencies = [
  "mio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_cursor"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_input"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_screen 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_screen"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_style"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_terminal"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_cursor 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_utils"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.76 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -817,14 +733,6 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2006,15 +1914,12 @@ dependencies = [
 
 [[package]]
 name = "tui"
-version = "0.6.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cassowary 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossterm 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossterm 0.17.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2256,14 +2161,6 @@ dependencies = [
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum crossterm 0.17.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4919d60f26ae233e14233cc39746c8c8bb8cd7b05840ace83604917b51b6c7"
-"checksum crossterm 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "21ac79357981b3c35917a377e6138729b66316db7649f9f96fbb517bb02361e5"
-"checksum crossterm_cursor 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fb4bfd085f17d83e6cd2943f0150d3b4331e465de8dba1750d1966192faf63dc"
-"checksum crossterm_input 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c6dd255ca05a596bae31ec392fdb67a829509bb767213f00f37c6b62814db663"
-"checksum crossterm_screen 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf294484fc34c22d514c41afc0b97ce74e10ea54d6eb5fe4806d1e1ac0f7b76"
-"checksum crossterm_style 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "983596405fe738aac9645656b666073fe6e0a8bf088679b7e256916ee41b61f7"
-"checksum crossterm_terminal 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "db8546b519e0c26aa1f43a4a4ea45ccb41eaca74b9a753ea1788f9ad90212636"
-"checksum crossterm_utils 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f874a71b2040c730669ddff805c9bc2a1a2f6de9d7f6aab2ae8d29ccbf8a0617"
-"checksum crossterm_winapi 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b055e7cc627c452e6a9b977022f48a2db6f0ff73df446ca970f95eef9c381d45"
 "checksum crossterm_winapi 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c"
 "checksum derive-new 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
@@ -2307,7 +2204,6 @@ dependencies = [
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
 "checksum ipnetwork 0.12.8 (registry+https://github.com/rust-lang/crates.io-index)" = "70783119ac90828aaba91eae39db32c6c1b8838deea3637e5238efa0130801ab"
 "checksum ipnetwork 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
-"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -2439,7 +2335,7 @@ dependencies = [
 "checksum tokio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e765bf9f550bd9b8a970633ca3b56b8120c4b6c5dcbe26a93744cb02fee4b17"
 "checksum trust-dns-proto 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "253a722ff22a1217b7af6199cb2ec5824a19c5110e0db21d3fcb28d5f6e1b0ee"
 "checksum trust-dns-resolver 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72d7df08b45f4d6d124cdae3c303f9908159a17b39e633e524349e91bc798d32"
-"checksum tui 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b422ff4986065d33272b587907654f918a3fe8702786a8110bf68dede0d8ee"
+"checksum tui 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a977b0bb2e2033a6fef950f218f13622c3c34e59754b704ce3492dedab1dfe95"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["src/tests/*", "demo.gif"]
 [dependencies]
 pnet = "0.26.0"
 ipnetwork = "0.16.0"
-tui = { version = "0.6", default-features = false, features = ["crossterm"]}
+tui = { version = "0.10", default-features = false, features = ["crossterm"]}
 crossterm = "0.17.7"
 structopt = "0.3"
 failure = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["src/tests/*", "demo.gif"]
 [dependencies]
 pnet = "0.26.0"
 ipnetwork = "0.16.0"
-tui = { version = "0.10", default-features = false, features = ["crossterm"]}
+tui = { version = "0.12", default-features = false, features = ["crossterm"]}
 crossterm = "0.17.7"
 structopt = "0.3"
 failure = "0.1.6"

--- a/src/display/components/header_details.rs
+++ b/src/display/components/header_details.rs
@@ -4,7 +4,8 @@ use ::tui::backend::Backend;
 use ::tui::layout::{Alignment, Rect};
 use ::tui::style::{Color, Modifier, Style};
 use ::tui::terminal::Frame;
-use ::tui::widgets::{Paragraph, Text, Widget};
+use ::tui::text::Span;
+use ::tui::widgets::Paragraph;
 
 const SECONDS_IN_DAY: u64 = 86400;
 
@@ -53,16 +54,13 @@ impl<'a> HeaderDetails<'a> {
         bandwidth: &str,
         color: Color,
     ) {
-        let bandwidth_text = {
-            [Text::styled(
-                bandwidth,
-                Style::default().fg(color).modifier(Modifier::BOLD),
-            )]
-        };
+        let bandwidth_text = Span::styled(
+            bandwidth,
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        );
 
-        Paragraph::new(bandwidth_text.iter())
-            .alignment(Alignment::Left)
-            .render(frame, rect);
+        let paragraph = Paragraph::new(bandwidth_text).alignment(Alignment::Left);
+        frame.render_widget(paragraph, rect);
     }
 
     fn bandwidth_string(&self) -> String {
@@ -88,13 +86,12 @@ impl<'a> HeaderDetails<'a> {
         elapsed_time: &str,
         color: Color,
     ) {
-        let elapsed_time_text = [Text::styled(
+        let elapsed_time_text = Span::styled(
             elapsed_time,
-            Style::default().fg(color).modifier(Modifier::BOLD),
-        )];
-        Paragraph::new(elapsed_time_text.iter())
-            .alignment(Alignment::Right)
-            .render(frame, rect);
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        );
+        let paragraph = Paragraph::new(elapsed_time_text).alignment(Alignment::Right);
+        frame.render_widget(paragraph, rect);
     }
 
     fn days_string(&self) -> String {

--- a/src/display/components/help_text.rs
+++ b/src/display/components/help_text.rs
@@ -42,7 +42,7 @@ impl HelpText {
         };
 
         let text = Span::styled(
-            format!("{}{}{}", pause_content, tab_text, dns_content),
+            [pause_content, tab_text, dns_content].concat(),
             Style::default().add_modifier(Modifier::BOLD),
         );
         let paragraph = Paragraph::new(text).alignment(Alignment::Left);

--- a/src/display/components/help_text.rs
+++ b/src/display/components/help_text.rs
@@ -2,7 +2,8 @@ use ::tui::backend::Backend;
 use ::tui::layout::{Alignment, Rect};
 use ::tui::style::{Modifier, Style};
 use ::tui::terminal::Frame;
-use ::tui::widgets::{Paragraph, Text, Widget};
+use ::tui::text::Span;
+use ::tui::widgets::Paragraph;
 
 pub struct HelpText {
     pub paused: bool,
@@ -20,34 +21,31 @@ const TEXT_TAB_TIP: &str = " Use <TAB> to rearrange tables.";
 
 impl HelpText {
     pub fn render(&self, frame: &mut Frame<impl Backend>, rect: Rect) {
-        let text = {
-            let pause_content = if self.paused {
-                TEXT_WHEN_PAUSED
-            } else {
-                TEXT_WHEN_NOT_PAUSED
-            };
-
-            let dns_content = if rect.width <= FIRST_WIDTH_BREAKPOINT {
-                ""
-            } else if self.show_dns {
-                TEXT_WHEN_DNS_SHOWN
-            } else {
-                TEXT_WHEN_DNS_NOT_SHOWN
-            };
-
-            let tab_text = if rect.width <= SECOND_WIDTH_BREAKPOINT {
-                ""
-            } else {
-                TEXT_TAB_TIP
-            };
-
-            [Text::styled(
-                format!("{}{}{}", pause_content, tab_text, dns_content),
-                Style::default().modifier(Modifier::BOLD),
-            )]
+        let pause_content = if self.paused {
+            TEXT_WHEN_PAUSED
+        } else {
+            TEXT_WHEN_NOT_PAUSED
         };
-        Paragraph::new(text.iter())
-            .alignment(Alignment::Left)
-            .render(frame, rect);
+
+        let dns_content = if rect.width <= FIRST_WIDTH_BREAKPOINT {
+            ""
+        } else if self.show_dns {
+            TEXT_WHEN_DNS_SHOWN
+        } else {
+            TEXT_WHEN_DNS_NOT_SHOWN
+        };
+
+        let tab_text = if rect.width <= SECOND_WIDTH_BREAKPOINT {
+            ""
+        } else {
+            TEXT_TAB_TIP
+        };
+
+        let text = Span::styled(
+            format!("{}{}{}", pause_content, tab_text, dns_content),
+            Style::default().add_modifier(Modifier::BOLD),
+        );
+        let paragraph = Paragraph::new(text).alignment(Alignment::Left);
+        frame.render_widget(paragraph, rect);
     }
 }

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -3,10 +3,10 @@ use ::std::iter::FromIterator;
 use ::unicode_width::UnicodeWidthChar;
 
 use ::tui::backend::Backend;
-use ::tui::layout::Rect;
+use ::tui::layout::{Constraint, Rect};
 use ::tui::style::{Color, Style};
 use ::tui::terminal::Frame;
-use ::tui::widgets::{Block, Borders, Row, Widget};
+use ::tui::widgets::{Block, Borders, Row};
 
 use crate::display::{Bandwidth, DisplayBandwidth, UIState};
 use crate::network::{display_connection_string, display_ip_or_host};
@@ -216,7 +216,7 @@ impl<'a> Table<'a> {
             0,
             ColumnData {
                 column_count: ColumnCount::Two,
-                column_widths: vec![12, 23],
+                column_widths: vec![15, 20],
             },
         );
         breakpoints.insert(
@@ -290,13 +290,14 @@ impl<'a> Table<'a> {
         });
 
         let table_rows = rows.map(|row| Row::StyledData(row.into_iter(), Style::default()));
-
-        ::tui::widgets::Table::new(column_names.into_iter(), table_rows)
+        let width_constraints: Vec<Constraint> =
+            widths.iter().map(|w| Constraint::Length(*w)).collect();
+        let table = ::tui::widgets::Table::new(column_names.into_iter(), table_rows)
             .block(Block::default().title(self.title).borders(Borders::ALL))
             .header_style(Style::default().fg(Color::Yellow))
-            .widths(&widths[..])
+            .widths(&width_constraints)
             .style(Style::default())
-            .column_spacing(column_spacing)
-            .render(frame, rect);
+            .column_spacing(column_spacing);
+        frame.render_widget(table, rect);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,8 @@ fn try_main() -> Result<(), failure::Error> {
     } else {
         match terminal::enable_raw_mode() {
             Ok(()) => {
-                let terminal_backend = CrosstermBackend::new();
+                let stdout = std::io::stdout();
+                let terminal_backend = CrosstermBackend::new(stdout);
                 start(terminal_backend, os_input, opts);
             }
             Err(_) => failure::bail!(

--- a/src/tests/cases/snapshots/ui__layout_under_50_width_under_50_height-2.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_50_width_under_50_height-2.snap
@@ -29,10 +29,10 @@ expression: "&terminal_draw_events_mirror[1]"
                                                  
                                                  
                                                  
- 3.3.3.3            0Bps / 28Bps                 
- 2.2.2.2            0Bps / 26Bps                 
- 1.1.1.1            0Bps / 22Bps                 
- 4.4.4.4            0Bps / 21Bps                 
+ 3.3.3.3               0Bps / 28Bps              
+ 2.2.2.2               0Bps / 26Bps              
+ 1.1.1.1               0Bps / 22Bps              
+ 4.4.4.4               0Bps / 21Bps              
                                                  
                                                  
                                                  

--- a/src/tests/cases/snapshots/ui__layout_under_50_width_under_50_height.snap
+++ b/src/tests/cases/snapshots/ui__layout_under_50_width_under_50_height.snap
@@ -27,7 +27,7 @@ expression: "&terminal_draw_events_mirror[0]"
 │                                               │
 └───────────────────────────────────────────────┘
 ┌Utilization by remote address──────────────────┐
-│Remote Address     Up / Down                   │
+│Remote Address        Up / Down                │
 │                                               │
 │                                               │
 │                                               │

--- a/src/tests/cases/snapshots/ui__two_windows_split_horizontally.snap
+++ b/src/tests/cases/snapshots/ui__two_windows_split_horizontally.snap
@@ -4,7 +4,7 @@ expression: "&terminal_draw_events_mirror[0]"
 ---
  Total Up / Down: 0Bps / 0Bps                               
 ┌Utilization by remote address─────────────────────────────┐
-│Remote Address          Up / Down                         │
+│Remote Address             Up / Down                      │
 │                                                          │
 │                                                          │
 │                                                          │

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -32,7 +32,9 @@ fn basic_startup() {
     start(backend, os_input, opts);
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
-    let expected_terminal_events = vec![Clear, HideCursor, Draw, Flush, Clear, ShowCursor];
+    let expected_terminal_events = vec![
+        Clear, HideCursor, Draw, HideCursor, Flush, Clear, ShowCursor,
+    ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
         &expected_terminal_events[..]
@@ -88,7 +90,8 @@ fn pause_by_space() {
     start(backend, os_input, opts);
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -143,8 +146,8 @@ fn rearranged_by_tab() {
     start(backend, os_input, opts);
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Draw, Flush, Draw, Flush, Clear,
-        ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -405,7 +408,7 @@ fn one_packet_of_traffic() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -428,7 +431,7 @@ fn bi_directional_traffic() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -466,7 +469,7 @@ fn multiple_packets_of_traffic_from_different_connections() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -504,7 +507,7 @@ fn multiple_packets_of_traffic_from_single_connection() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -542,7 +545,7 @@ fn one_process_with_multiple_connections() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -594,7 +597,7 @@ fn multiple_processes_with_multiple_connections() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -632,7 +635,7 @@ fn multiple_connections_from_remote_address() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -672,7 +675,8 @@ fn sustained_traffic_from_one_process() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -713,7 +717,8 @@ fn sustained_traffic_from_one_process_total() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -767,7 +772,8 @@ fn sustained_traffic_from_multiple_processes() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -822,7 +828,8 @@ fn sustained_traffic_from_multiple_processes_total() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -904,7 +911,8 @@ fn sustained_traffic_from_multiple_processes_bi_directional() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -987,7 +995,8 @@ fn sustained_traffic_from_multiple_processes_bi_directional_total() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1092,7 +1101,8 @@ fn traffic_with_host_names() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1197,7 +1207,8 @@ fn truncate_long_hostnames() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1301,7 +1312,8 @@ fn no_resolve_mode() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1341,7 +1353,8 @@ fn traffic_with_winch_event() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Draw, HideCursor,
+        Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1395,7 +1408,7 @@ fn layout_full_width_under_30_height() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1447,7 +1460,7 @@ fn layout_under_120_width_full_height() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1498,7 +1511,7 @@ fn layout_under_120_width_under_30_height() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1549,7 +1562,7 @@ fn layout_under_50_width_under_50_height() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],
@@ -1600,7 +1613,7 @@ fn layout_under_70_width_under_30_height() {
     let terminal_draw_events_mirror = terminal_draw_events.lock().unwrap();
 
     let expected_terminal_events = vec![
-        Clear, HideCursor, Draw, Flush, Draw, Flush, Clear, ShowCursor,
+        Clear, HideCursor, Draw, HideCursor, Flush, Draw, HideCursor, Flush, Clear, ShowCursor,
     ];
     assert_eq!(
         &terminal_events.lock().unwrap()[..],


### PR DESCRIPTION
Recently, as part of adding Windows support, we switched our TUI backend to Crossterm.
This broke the build for FreeBSD here: https://github.com/imsnif/bandwhich/issues/188. In short, TUI was depending on an old version of Crossterm that had a bug when building for FreeBSD.
To fix this, I issued a hot fix here: https://github.com/imsnif/bandwhich/pull/189. This upgraded TUI from 0.5 to 0.6.2, which included the FreeBSD fix, but did not have all the breaking API changes from the latest published TUI version (0.10.0).

While this did solve the problem, it did break the UI. When running locally, I was unable to see the "Total Utilization" line at the top, as well as other small glitches.

This PR solves this issue by upgrading tui to the latest version (0.10.0), accounting for all the API changes.

For ease of review, I'm going to sum the relevant parts here:
* Instead of the deprecated `Text` TUI widget, we're now using `Span`
* Instead of rendering widgets through their render function (deprecated behaviour), we're now providing them to `Frame::render_widget`
* In `Paragraph`, we can provide the `Span`s directly instead of wrapping them in something we can iterate over. (MUCH better IMO :) ).
* In `Table`, we now have to provide the widths as tui `Constraint` instances (not so nice for our use case, but the extra allocations are very minimal I think).
* We now need to provide the `Crossterm` backend with the system stdout. In our case this is not very elegant, but we should still get cross-platform functionality from the rust `std::io` itself, and it doesn't interfere with our tests - so I think it's fine.
* I changed some widths in the `Table` columns in a 2-column table-layout, because otherwise one of the titles (Remote Addresses) got cut off.
* For some reason TUI now seems to invoke `hide_cursor`/`show_cursor` before every `flush`. I updated these in the tests - I don't think there is any user facing effect.

@TheLostLambda - if you have time to review this (can wait a few days or even a week if you don't have the time) that would be great. If not I'll get a different pair of eyes on this.