### PR TITLE
Adding --add-payload-offset flag (macos only) [and 1.48 updates]

### DIFF
--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -31,10 +31,7 @@ where
         let mut terminal = Terminal::new(terminal_backend).unwrap();
         terminal.clear().unwrap();
         terminal.hide_cursor().unwrap();
-        let state = UIState {
-            cumulative_mode: opts.total_utilization,
-            ..Default::default()
-        };
+        let state = UIState::with_cumulative_mode(opts.total_utilization);
         Ui {
             terminal,
             state,

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -86,6 +86,13 @@ pub struct UIState {
 }
 
 impl UIState {
+    pub fn with_cumulative_mode(cumulative_mode: bool) -> Self {
+        UIState {
+            cumulative_mode,
+            ..Default::default()
+        }
+    }
+
     fn get_proc_name<'a>(
         connections_to_procs: &'a HashMap<LocalSocket, String>,
         local_socket: &LocalSocket,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,10 +52,10 @@ pub struct Opt {
     #[structopt(short, long)]
     /// A dns server ip to use instead of the system default
     dns_server: Option<Ipv4Addr>,
-    #[cfg(target_os = "macos")]
-    #[structopt(short = "o", long)]
-    /// Remove default payload offset for Point-to-Point interfaces
-    no_payload_offset: bool,
+    #[cfg_attr(not(target_os = "macos"), structopt(skip = false))]
+    #[cfg_attr(target_os = "macos", structopt(short = "o", long))]
+    /// Add a 14-byte payload offset needed for some utun (Point-to-Point) interfaces
+    add_payload_offset: bool,
 }
 
 #[derive(StructOpt, Debug, Copy, Clone)]
@@ -293,10 +293,7 @@ where
             let name = format!("sniffing_handler_{}", iface.name);
             let running = running.clone();
             let show_dns = opts.show_dns;
-            #[cfg(target_os = "macos")]
-            let with_payload_offset = !opts.no_payload_offset;
-            #[cfg(not(target_os = "macos"))]
-            let with_payload_offset = false;
+            let with_payload_offset = opts.add_payload_offset;
             let network_utilization = network_utilization.clone();
 
             thread::Builder::new()

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -99,12 +99,12 @@ impl Sniffer {
     ) -> Self {
         let payload_offset = {
             // See https://github.com/libpnet/libpnet/blob/master/examples/packetdump.rs
-            // VPN interfaces (such as utun0, utun1, etc) have POINT_TO_POINT bit set to 1
-            if with_payload_offset
-                && (network_interface.is_loopback() || network_interface.is_point_to_point())
-                && cfg!(target_os = "macos")
+            // The pnet code for BPF loopback adds a zero'd out Ethernet header
+            if cfg!(target_os = "macos")
+                && (network_interface.is_loopback()
+                    // utun interfaces shouldn't need the offset, but user can add with a flag
+                    || (with_payload_offset && network_interface.is_point_to_point()))
             {
-                // The pnet code for BPF loopback adds a zero'd out Ethernet header
                 14
             } else {
                 0

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -87,6 +87,7 @@ pub struct Sniffer {
     network_interface: NetworkInterface,
     network_frames: Box<dyn DataLinkReceiver>,
     dns_shown: bool,
+    payload_offset: usize,
 }
 
 impl Sniffer {
@@ -94,11 +95,26 @@ impl Sniffer {
         network_interface: NetworkInterface,
         network_frames: Box<dyn DataLinkReceiver>,
         dns_shown: bool,
+        with_payload_offset: bool,
     ) -> Self {
+        let payload_offset = {
+            // See https://github.com/libpnet/libpnet/blob/master/examples/packetdump.rs
+            // VPN interfaces (such as utun0, utun1, etc) have POINT_TO_POINT bit set to 1
+            if with_payload_offset
+                && (network_interface.is_loopback() || network_interface.is_point_to_point())
+                && cfg!(target_os = "macos")
+            {
+                // The pnet code for BPF loopback adds a zero'd out Ethernet header
+                14
+            } else {
+                0
+            }
+        };
         Sniffer {
             network_interface,
             network_frames,
             dns_shown,
+            payload_offset,
         }
     }
     pub fn next(&mut self) -> Option<Segment> {
@@ -116,24 +132,14 @@ impl Sniffer {
                 }
             },
         };
-        // See https://github.com/libpnet/libpnet/blob/master/examples/packetdump.rs
-        // VPN interfaces (such as utun0, utun1, etc) have POINT_TO_POINT bit set to 1
-        let payload_offset = if (self.network_interface.is_loopback()
-            || self.network_interface.is_point_to_point())
-            && cfg!(target_os = "macos")
-        {
-            // The pnet code for BPF loopback adds a zero'd out Ethernet header
-            14
-        } else {
-            0
-        };
-        let ip_packet = Ipv4Packet::new(&bytes[payload_offset..])?;
+
+        let ip_packet = Ipv4Packet::new(&bytes[self.payload_offset..])?;
         let version = ip_packet.get_version();
 
         match version {
             4 => Self::handle_v4(ip_packet, &self.network_interface, self.dns_shown),
             6 => Self::handle_v6(
-                Ipv6Packet::new(&bytes[payload_offset..])?,
+                Ipv6Packet::new(&bytes[self.payload_offset..])?,
                 &self.network_interface,
             ),
             _ => {

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -584,6 +584,8 @@ fn no_resolve_mode() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
     start(backend, os_input, opts);
     let stdout = Arc::try_unwrap(stdout).unwrap().into_inner().unwrap();

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -584,8 +584,7 @@ fn no_resolve_mode() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
     start(backend, os_input, opts);
     let stdout = Arc::try_unwrap(stdout).unwrap().into_inner().unwrap();

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -165,8 +165,7 @@ fn opts_factory(raw: bool) -> Opt {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     }
 }
 type BackendWithStreams = (

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -165,6 +165,8 @@ fn opts_factory(raw: bool) -> Opt {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     }
 }
 type BackendWithStreams = (

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -181,8 +181,7 @@ fn basic_only_processes() {
             processes: true,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -210,8 +209,7 @@ fn basic_processes_with_dns_queries() {
             processes: true,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -239,8 +237,7 @@ fn basic_only_connections() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -268,8 +265,7 @@ fn basic_only_addresses() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -295,8 +291,7 @@ fn two_packets_only_processes() {
             processes: true,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -323,8 +318,7 @@ fn two_packets_only_connections() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -351,8 +345,7 @@ fn two_packets_only_addresses() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -381,8 +374,7 @@ fn two_windows_split_horizontally() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -410,8 +402,7 @@ fn two_windows_split_vertically() {
             processes: false,
             total_utilization: false,
         },
-        #[cfg(target_os = "macos")]
-        no_payload_offset: false,
+        add_payload_offset: false,
     };
 
     start(backend, os_input, opts);

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -181,6 +181,8 @@ fn basic_only_processes() {
             processes: true,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -208,6 +210,8 @@ fn basic_processes_with_dns_queries() {
             processes: true,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -235,6 +239,8 @@ fn basic_only_connections() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -262,6 +268,8 @@ fn basic_only_addresses() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -287,6 +295,8 @@ fn two_packets_only_processes() {
             processes: true,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -313,6 +323,8 @@ fn two_packets_only_connections() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -339,6 +351,8 @@ fn two_packets_only_addresses() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -367,6 +381,8 @@ fn two_windows_split_horizontally() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);
@@ -394,6 +410,8 @@ fn two_windows_split_vertically() {
             processes: false,
             total_utilization: false,
         },
+        #[cfg(target_os = "macos")]
+        no_payload_offset: false,
     };
 
     start(backend, os_input, opts);


### PR DESCRIPTION
Follow-up for #129: Not all "macos" Point-to-point (E.g. utun) interfaces use a payload offset, according to [libpnet](https://github.com/libpnet/libpnet/blob/07e73e2c60dcec7a3655ea79876058037a57fff6/pnet_datalink/src/bpf.rs#L263,L266). This PR removes the offset for VPN interfaces by default and adds an `--add-payload-offset` flag to allow the offset when desired.

- Moves payload_offset calculation to Sniffer::new to evaluate network interface and `cfg!` conditions once
- Targets "macos" only (since payload_offset calculation in `Sniffer` only affects `cfg!(target_os = "macos")`
  - This does make the code a little messy (especially in the tests), but it wouldn't make sense to have this option for non-macos targets. I'm open to suggestions around dealing with this handling