### PR TITLE
feat(dns): allow custom dns server as cli flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use ::tui::backend::Backend;
 
 use std::process;
 
+use ::std::net::Ipv4Addr;
 use ::std::time::{Duration, Instant};
 use ::tui::backend::CrosstermBackend;
 use std::sync::RwLock;
@@ -48,6 +49,9 @@ pub struct Opt {
     #[structopt(short, long)]
     /// Show DNS queries
     show_dns: bool,
+    #[structopt(short, long)]
+    /// A dns server ip to use instead of the system default
+    dns_server: Option<Ipv4Addr>,
 }
 
 #[derive(StructOpt, Debug, Copy, Clone)]
@@ -76,7 +80,7 @@ fn main() {
 fn try_main() -> Result<(), failure::Error> {
     use os::get_input;
     let opts = Opt::from_args();
-    let os_input = get_input(&opts.interface, !opts.no_resolve)?;
+    let os_input = get_input(&opts.interface, !opts.no_resolve, &opts.dns_server)?;
     let raw_mode = opts.raw;
     if raw_mode {
         let terminal_backend = RawTerminalBackend {};

--- a/src/network/dns/resolver.rs
+++ b/src/network/dns/resolver.rs
@@ -22,7 +22,6 @@ impl Resolver {
             Some(dns_server_address) => {
                 let mut config = ResolverConfig::new();
                 let options = ResolverOpts::default();
-                // let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), 53));
                 let socket = SocketAddr::V4(SocketAddrV4::new(*dns_server_address, 53));
                 let nameserver_config = NameServerConfig {
                     socket_addr: socket,

--- a/src/network/dns/resolver.rs
+++ b/src/network/dns/resolver.rs
@@ -1,6 +1,9 @@
 use async_trait::async_trait;
 use std::net::IpAddr;
+use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddrV4};
 use tokio::runtime::Handle;
+use trust_dns_resolver::config::{NameServerConfig, Protocol, ResolverConfig, ResolverOpts};
 use trust_dns_resolver::{error::ResolveErrorKind, TokioAsyncResolver};
 
 #[async_trait]
@@ -11,8 +14,26 @@ pub trait Lookup {
 pub struct Resolver(TokioAsyncResolver);
 
 impl Resolver {
-    pub async fn new(runtime: Handle) -> Result<Self, failure::Error> {
-        let resolver = TokioAsyncResolver::from_system_conf(runtime).await?;
+    pub async fn new(
+        runtime: Handle,
+        dns_server: &Option<Ipv4Addr>,
+    ) -> Result<Self, failure::Error> {
+        let resolver = match dns_server {
+            Some(dns_server_address) => {
+                let mut config = ResolverConfig::new();
+                let options = ResolverOpts::default();
+                // let socket = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), 53));
+                let socket = SocketAddr::V4(SocketAddrV4::new(*dns_server_address, 53));
+                let nameserver_config = NameServerConfig {
+                    socket_addr: socket,
+                    protocol: Protocol::Udp,
+                    tls_dns_name: None,
+                };
+                config.add_name_server(nameserver_config);
+                TokioAsyncResolver::new(config, options, runtime).await?
+            }
+            None => TokioAsyncResolver::from_system_conf(runtime).await?,
+        };
         Ok(Self(resolver))
     }
 }

--- a/src/tests/cases/raw_mode.rs
+++ b/src/tests/cases/raw_mode.rs
@@ -577,6 +577,7 @@ fn no_resolve_mode() {
         raw: true,
         no_resolve: true,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: false,

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -158,6 +158,7 @@ fn opts_factory(raw: bool) -> Opt {
         raw,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: false,

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -174,6 +174,7 @@ fn basic_only_processes() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: false,
@@ -200,6 +201,7 @@ fn basic_processes_with_dns_queries() {
         raw: false,
         no_resolve: false,
         show_dns: true,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: false,
@@ -226,6 +228,7 @@ fn basic_only_connections() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: true,
@@ -252,6 +255,7 @@ fn basic_only_addresses() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: true,
             connections: false,
@@ -276,6 +280,7 @@ fn two_packets_only_processes() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: false,
@@ -301,6 +306,7 @@ fn two_packets_only_connections() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: false,
             connections: true,
@@ -326,6 +332,7 @@ fn two_packets_only_addresses() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: true,
             connections: false,
@@ -353,6 +360,7 @@ fn two_windows_split_horizontally() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: true,
             connections: true,
@@ -379,6 +387,7 @@ fn two_windows_split_vertically() {
         raw: false,
         no_resolve: false,
         show_dns: false,
+        dns_server: None,
         render_opts: RenderOpts {
             addresses: true,
             connections: true,


### PR DESCRIPTION
Since there are some cases in which we don't properly detect the system dns servers to performs reverse dns lookup, I added a CLI option that would allow users to manually specify a dns server as a workaround.

Usage example:
`sudo bandwhich --dns-server 1.1.1.1`