### PR TITLE
Feature/autocomplete script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ BIN=target/$(TARGET)/$(APP)
 BIN_DST=$(DESTDIR)$(prefix)/bin/$(APP)
 DOC_DST=$(DESTDIR)$(prefix)/share/man/man1/bandwhich.1
 LIC_DST=$(DESTDIR)$(prefix)/share/licenses/$(APP)
+AUTOCOMPLETE_DST=/usr/share/bash-completion/completions
 SRC = Makefile Cargo.lock Cargo.toml $(shell find src -type f -wholename 'src/*.rs')
 
-.PHONY: all clean distclean install uninstall vendor
+.PHONY: all clean distclean install uninstall vendor install_autocomplete
 
 all: $(BIN)
 
@@ -35,12 +36,19 @@ ifeq ($(VENDOR),1)
 endif
 	cargo build $(ARGS)
 
-install:
+install_autocomplete:
+	mkdir -p $(AUTOCOMPLETE_DST)
+	cp src/bandwhich $(AUTOCOMPLETE_DST)/bandwhich
+
+uninstall_autocomplete:
+	rm -f $(AUTOCOMPLETE_DST)/bandwhich
+
+install: install_autocomplete
 	install -Dm755 $(BIN) $(BIN_DST)
 	install -Dm644 docs/bandwhich.1 $(DOC_DST)
 	install -Dm644 LICENSE.md $(LIC_DST)/LICENSE
 
-uninstall:
+uninstall: uninstall_autocomplete
 	rm -rf $(BIN_DST) $(DOC_DST) $(LIC_DST)
 
 vendor:

--- a/src/bandwhich
+++ b/src/bandwhich
@@ -1,0 +1,31 @@
+# bandwhich completion                                      -*- shell-script -*-
+
+_bandwhich()
+{
+    local cur prev flags opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    flags="--addresses --connections --help --no-resolve
+            --processes --raw --show-dns --total-utilization --version"
+    opts="--dns-server --interface"
+
+    interfaces=$(ip link show | grep -o ": .*:" | sed 's/[: ]//g' | tr '\n' ' ')
+    case "${prev}" in
+        --interface)
+            COMPREPLY=( $(compgen -W "${interfaces}" -- "${cur}"))
+            return
+            ;;
+    esac
+
+    case "${cur}" in
+        --interface)
+            COMPREPLY=( $(compgen -W "${interfaces}"))
+            ;;
+        -*)
+            COMPREPLY=( $(compgen -W "${flags} ${opts}" -- "${cur}"))
+            ;;
+    esac
+} &&
+
+complete -o nospace -F _bandwhich bandwhich


### PR DESCRIPTION
Add a bash autocomplete script.
It autocompletes the _bandwhich_ command with the different flags and options.
If the _--interface_ option is used, then it autocompletes it using the different network interfaces obtained from _ip link show_ which should be the default on most Linux distributions now.