### PR TITLE
Download pcap-sdk-1.05.zip from new location

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn download_winpcap_sdk() {
 
     let mut reader = Vec::new();
     let _res = request::get(
-        "https://nmap.org/npcap/dist/npcap-sdk-1.05.zip",
+        "https://npcap.com/dist/npcap-sdk-1.05.zip",
         &mut reader,
     )
     .unwrap();


### PR DESCRIPTION
The pcap SDK was moved but http_req doesn't support redirects.