### PR TITLE
Ignore connections that fail parsing instead of panicking on BSD

### DIFF
--- a/src/os/lsof.rs
+++ b/src/os/lsof.rs
@@ -1,29 +1,10 @@
-use std::collections::HashMap;
-
-use crate::{network::LocalSocket, os::lsof_utils::get_connections, OpenSockets};
+use crate::{os::lsof_utils::get_connections, OpenSockets};
 
 pub(crate) fn get_open_sockets() -> OpenSockets {
-    let mut open_sockets = HashMap::new();
+    let sockets_to_procs = get_connections()
+        .into_iter()
+        .filter_map(|raw| raw.as_local_socket().map(|s| (s, raw.process_name)))
+        .collect();
 
-    let connections = get_connections();
-
-    for raw_connection in connections {
-        let Some(ip) = raw_connection.get_local_ip() else {
-            continue;
-        };
-        let Some(port) = raw_connection.get_local_port() else {
-            continue;
-        };
-        let Some(protocol) = raw_connection.get_protocol() else {
-            continue;
-        };
-        open_sockets.insert(
-            LocalSocket { ip, port, protocol },
-            raw_connection.process_name.clone(),
-        );
-    }
-
-    OpenSockets {
-        sockets_to_procs: open_sockets,
-    }
+    OpenSockets { sockets_to_procs }
 }

--- a/src/os/lsof.rs
+++ b/src/os/lsof.rs
@@ -2,7 +2,6 @@ use crate::{os::lsof_utils::get_connections, OpenSockets};
 
 pub(crate) fn get_open_sockets() -> OpenSockets {
     let sockets_to_procs = get_connections()
-        .into_iter()
         .filter_map(|raw| raw.as_local_socket().map(|s| (s, raw.process_name)))
         .collect();
 

--- a/src/os/lsof.rs
+++ b/src/os/lsof.rs
@@ -8,12 +8,17 @@ pub(crate) fn get_open_sockets() -> OpenSockets {
     let connections = get_connections();
 
     for raw_connection in connections {
+        let Some(ip) = raw_connection.get_local_ip() else {
+            continue;
+        };
+        let Some(port) = raw_connection.get_local_port() else {
+            continue;
+        };
+        let Some(protocol) = raw_connection.get_protocol() else {
+            continue;
+        };
         open_sockets.insert(
-            LocalSocket {
-                ip: raw_connection.get_local_ip(),
-                port: raw_connection.get_local_port(),
-                protocol: raw_connection.get_protocol(),
-            },
+            LocalSocket { ip, port, protocol },
             raw_connection.process_name.clone(),
         );
     }

--- a/src/os/lsof_utils.rs
+++ b/src/os/lsof_utils.rs
@@ -103,16 +103,16 @@ impl RawConnection {
         }
     }
 
-    pub fn get_protocol(&self) -> Protocol {
-        Protocol::from_str(&self.protocol).unwrap()
+    pub fn get_protocol(&self) -> Option<Protocol> {
+        Protocol::from_str(&self.protocol)
     }
 
-    pub fn get_local_ip(&self) -> IpAddr {
-        self.local_ip.parse().unwrap()
+    pub fn get_local_ip(&self) -> Option<IpAddr> {
+        self.local_ip.parse().ok()
     }
 
-    pub fn get_local_port(&self) -> u16 {
-        self.local_port.parse::<u16>().unwrap()
+    pub fn get_local_port(&self) -> Option<u16> {
+        self.local_port.parse::<u16>().ok()
     }
 }
 
@@ -203,7 +203,7 @@ com.apple   590 etoledom  204u  IPv4 0x28ffb9c04111253f      0t0  TCP 192.168.1.
     }
     fn test_raw_connection_parse_local_port(raw_output: &str) {
         let connection = RawConnection::new(raw_output).unwrap();
-        assert_eq!(connection.get_local_port(), 1111);
+        assert_eq!(connection.get_local_port(), Some(1111));
     }
 
     #[test]
@@ -216,7 +216,7 @@ com.apple   590 etoledom  204u  IPv4 0x28ffb9c04111253f      0t0  TCP 192.168.1.
     }
     fn test_raw_connection_parse_protocol(raw_line: &str) {
         let connection = RawConnection::new(raw_line).unwrap();
-        assert_eq!(connection.get_protocol(), Protocol::Udp);
+        assert_eq!(connection.get_protocol(), Some(Protocol::Udp));
     }
 
     #[test]

--- a/src/os/lsof_utils.rs
+++ b/src/os/lsof_utils.rs
@@ -1,8 +1,9 @@
 use std::{ffi::OsStr, net::IpAddr, process::Command, sync::OnceLock};
 
+use log::warn;
 use regex::Regex;
 
-use crate::network::Protocol;
+use crate::network::{LocalSocket, Protocol};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -113,6 +114,25 @@ impl RawConnection {
 
     pub fn get_local_port(&self) -> Option<u16> {
         self.local_port.parse::<u16>().ok()
+    }
+
+    pub fn as_local_socket(&self) -> Option<LocalSocket> {
+        let process = &self.process_name;
+
+        let Some(ip) = self.get_local_ip() else {
+            warn!(r#"Failed to get the local IP of a connection belonging to "{process}"."#);
+            return None;
+        };
+        let Some(port) = self.get_local_port() else {
+            warn!(r#"Failed to get the local port of a connection belonging to "{process}"."#);
+            return None;
+        };
+        let Some(protocol) = self.get_protocol() else {
+            warn!(r#"Failed to get the protocol of a connection belonging to "{process}"."#);
+            return None;
+        };
+
+        Some(LocalSocket { ip, port, protocol })
     }
 }
 


### PR DESCRIPTION
Will fix #217.

What I'm doing not is not ideal - I think there should be some kind of warning when parsing fails, but I'm not sure what's the most appropriate way to raise this warning. But at least it's better than panicking.

MacOS & BSD users can you please test this patch? Pay particular attention to whether there are missing connections. Thanks.

Further improvements very much welcomed.