### PR TITLE
Add logging infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "crossterm",
+ "derivative",
  "http_req",
  "insta",
  "ipnetwork",
@@ -473,6 +474,17 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "derive-new"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,10 +149,12 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "clap-verbosity-flag",
  "crossterm",
  "http_req",
  "insta",
  "ipnetwork",
+ "log",
  "netstat2",
  "packet-builder",
  "pnet",
@@ -163,6 +165,7 @@ dependencies = [
  "regex",
  "resolv-conf",
  "rstest",
+ "simplelog",
  "sysinfo",
  "thiserror",
  "tokio",
@@ -291,6 +294,16 @@ checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eef05769009513df2eb1c3b4613e7fad873a14c600ff025b08f250f59fee7de"
+dependencies = [
+ "clap",
+ "log",
 ]
 
 [[package]]
@@ -853,6 +866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1060,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1647,6 +1675,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
+name = "simplelog"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1795,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,8 +1830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
  "deranged",
+ "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1791,6 +1843,15 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tinyvec"
@@ -2059,6 +2120,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ resolv-conf = "0.7.0"
 pnet_macros_support = "0.34.0"
 anyhow = { version = "1.0.75", features = ["backtrace"] }
 thiserror = "1.0.49"
+log = "0.4.20"
+simplelog = "0.12.1"
+clap-verbosity-flag = "2.0.1"
 
 [target.'cfg(target_os="windows")'.dependencies]
 netstat2 = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,10 @@ thiserror = "1.0.49"
 log = "0.4.20"
 simplelog = "0.12.1"
 clap-verbosity-flag = "2.0.1"
+derivative = "2.2.0"
 
 [target.'cfg(target_os="windows")'.dependencies]
-netstat2 = "0.9.1"
+netstat2 = "0.9.1" 
 sysinfo = "0.29.10"
 
 [target.'cfg(target_os="linux")'.dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,11 @@
-use std::net::Ipv4Addr;
+use std::{net::Ipv4Addr, path::PathBuf};
 
 use clap::{Args, Parser};
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+use derivative::Derivative;
 
-#[derive(Clone, Debug, Default, Parser)]
+#[derive(Clone, Debug, Derivative, Parser)]
+#[derivative(Default)]
 #[command(name = "bandwhich", version)]
 pub struct Opt {
     #[arg(short, long)]
@@ -24,6 +27,14 @@ pub struct Opt {
     #[arg(short, long)]
     /// A dns server ip to use instead of the system default
     pub dns_server: Option<Ipv4Addr>,
+
+    #[arg(long)]
+    /// Enable logging to a file
+    pub log_to: Option<PathBuf>,
+
+    #[command(flatten)]
+    #[derivative(Default(value = "Verbosity::new(0, 0)"))]
+    pub verbosity: Verbosity<InfoLevel>,
 
     #[command(flatten)]
     pub render_opts: RenderOpts,


### PR DESCRIPTION
@konnorandrews suggested we use [tracing](https://crates.io/crates/tracing). But after taking a brief look at it, I thought it's too complex for our needs.

I opted to use [simplelog](https://crates.io/crates/simplelog), which is as uncomplicated as it gets.