### PR TITLE
Refactor `OsInputOutput` (combine interfaces & frames into single Vec)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,7 @@ pub struct OpenSockets {
 }
 
 pub struct OsInputOutput {
-    pub network_interfaces: Vec<NetworkInterface>,
-    pub network_frames: Vec<Box<dyn DataLinkReceiver>>,
+    pub interfaces_with_frames: Vec<(NetworkInterface, Box<dyn DataLinkReceiver>)>,
     pub get_open_sockets: fn() -> OpenSockets,
     pub terminal_events: Box<dyn Iterator<Item = Event> + Send>,
     pub dns_client: Option<dns::Client>,
@@ -281,9 +280,8 @@ where
     active_threads.push(terminal_event_handler);
 
     let sniffer_threads = os_input
-        .network_interfaces
+        .interfaces_with_frames
         .into_iter()
-        .zip(os_input.network_frames)
         .map(|(iface, frames)| {
             let name = format!("sniffing_handler_{}", iface.name);
             let running = running.clone();

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -130,6 +130,8 @@ pub fn get_input(
         });
 
     // bail if all of them fail
+    // note that `Iterator::all` returns `true` for an empty iterator, so it is important to handle
+    // that failure mode separately, which we already have
     if interfaces_with_frames_res
         .iter()
         .all(|(_, frames)| frames.is_err())

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-use itertools::Itertools;
 use packet_builder::*;
 use pnet::{datalink::DataLinkReceiver, packet::Packet};
 use pnet_base::MacAddr;
@@ -15,8 +14,8 @@ use rstest::fixture;
 use crate::{
     network::dns::Client,
     tests::fakes::{
-        create_fake_dns_client, get_interfaces, get_open_sockets, NetworkFrames, TerminalEvent,
-        TerminalEvents, TestBackend,
+        create_fake_dns_client, get_interfaces_with_frames, get_open_sockets, NetworkFrames,
+        TerminalEvent, TerminalEvents, TestBackend,
     },
     Opt, OsInputOutput,
 };
@@ -254,10 +253,7 @@ pub fn os_input_output_factory(
     dns_client: Option<Client>,
     keyboard_events: Box<dyn Iterator<Item = Event> + Send>,
 ) -> OsInputOutput {
-    let interfaces_with_frames = get_interfaces()
-        .into_iter()
-        .zip_eq(network_frames)
-        .collect();
+    let interfaces_with_frames = get_interfaces_with_frames(network_frames);
 
     let write_to_stdout: Box<dyn FnMut(String) + Send> = match stdout {
         Some(stdout) => Box::new({

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -17,7 +17,8 @@ use crate::{
             sleep_and_quit_events, sleep_resize_and_quit_events, test_backend_factory,
         },
         fakes::{
-            create_fake_dns_client, get_interfaces, get_open_sockets, NetworkFrames, TerminalEvents,
+            create_fake_dns_client, get_interfaces_with_frames, get_open_sockets, NetworkFrames,
+            TerminalEvents,
         },
     },
     Opt, OsInputOutput,
@@ -640,10 +641,7 @@ fn sustained_traffic_from_multiple_processes_bi_directional_total(
 fn traffic_with_host_names(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
-    let interfaces_with_frames = get_interfaces()
-        .into_iter()
-        .zip_eq(network_frames)
-        .collect();
+    let interfaces_with_frames = get_interfaces_with_frames(network_frames);
 
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
@@ -682,10 +680,7 @@ fn traffic_with_host_names(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
 fn truncate_long_hostnames(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
-    let interfaces_with_frames = get_interfaces()
-        .into_iter()
-        .zip_eq(network_frames)
-        .collect();
+    let interfaces_with_frames = get_interfaces_with_frames(network_frames);
 
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
@@ -724,10 +719,7 @@ fn truncate_long_hostnames(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
 fn no_resolve_mode(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
-    let interfaces_with_frames = get_interfaces()
-        .into_iter()
-        .zip_eq(network_frames)
-        .collect();
+    let interfaces_with_frames = get_interfaces_with_frames(network_frames);
 
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
@@ -771,10 +763,7 @@ fn traffic_with_winch_event() {
         12345,
         b"I am a fake tcp packet",
     ))]) as Box<dyn DataLinkReceiver>];
-    let interfaces_with_frames = get_interfaces()
-        .into_iter()
-        .zip_eq(network_frames)
-        .collect();
+    let interfaces_with_frames = get_interfaces_with_frames(network_frames);
 
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -640,6 +640,11 @@ fn sustained_traffic_from_multiple_processes_bi_directional_total(
 fn traffic_with_host_names(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
+    let interfaces_with_frames = get_interfaces()
+        .into_iter()
+        .zip_eq(network_frames)
+        .collect();
+
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -657,8 +662,7 @@ fn traffic_with_host_names(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
-        network_interfaces: get_interfaces(),
-        network_frames,
+        interfaces_with_frames,
         get_open_sockets,
         terminal_events: sleep_and_quit_events(3),
         dns_client,
@@ -678,6 +682,11 @@ fn traffic_with_host_names(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
 fn truncate_long_hostnames(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
+    let interfaces_with_frames = get_interfaces()
+        .into_iter()
+        .zip_eq(network_frames)
+        .collect();
+
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -695,8 +704,7 @@ fn truncate_long_hostnames(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
-        network_interfaces: get_interfaces(),
-        network_frames,
+        interfaces_with_frames,
         get_open_sockets,
         terminal_events: sleep_and_quit_events(3),
         dns_client,
@@ -716,6 +724,11 @@ fn truncate_long_hostnames(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
 fn no_resolve_mode(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
+    let interfaces_with_frames = get_interfaces()
+        .into_iter()
+        .zip_eq(network_frames)
+        .collect();
+
     let mut ips_to_hostnames = HashMap::new();
     ips_to_hostnames.insert(
         IpAddr::V4("1.1.1.1".parse().unwrap()),
@@ -733,8 +746,7 @@ fn no_resolve_mode(network_frames: Vec<Box<dyn DataLinkReceiver>>) {
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
-        network_interfaces: get_interfaces(),
-        network_frames,
+        interfaces_with_frames,
         get_open_sockets,
         terminal_events: sleep_and_quit_events(3),
         dns_client,
@@ -759,6 +771,10 @@ fn traffic_with_winch_event() {
         12345,
         b"I am a fake tcp packet",
     ))]) as Box<dyn DataLinkReceiver>];
+    let interfaces_with_frames = get_interfaces()
+        .into_iter()
+        .zip_eq(network_frames)
+        .collect();
 
     let (terminal_events, terminal_draw_events, backend) = test_backend_factory(190, 50);
 
@@ -766,8 +782,7 @@ fn traffic_with_winch_event() {
     let write_to_stdout = Box::new(move |_output: String| {});
 
     let os_input = OsInputOutput {
-        network_interfaces: get_interfaces(),
-        network_frames,
+        interfaces_with_frames,
         get_open_sockets,
         terminal_events: sleep_resize_and_quit_events(2),
         dns_client,

--- a/src/tests/fakes/fake_input.rs
+++ b/src/tests/fakes/fake_input.rs
@@ -7,6 +7,7 @@ use std::{
 use async_trait::async_trait;
 use crossterm::event::Event;
 use ipnetwork::IpNetwork;
+use itertools::Itertools;
 use pnet::datalink::{DataLinkReceiver, NetworkInterface};
 use tokio::runtime::Runtime;
 
@@ -157,6 +158,12 @@ pub fn get_interfaces() -> Vec<NetworkInterface> {
         // at offset 14
         flags: 0,
     }]
+}
+
+pub fn get_interfaces_with_frames(
+    frames: impl IntoIterator<Item = Box<dyn DataLinkReceiver>>,
+) -> Vec<(NetworkInterface, Box<dyn DataLinkReceiver>)> {
+    get_interfaces().into_iter().zip_eq(frames).collect()
 }
 
 pub fn create_fake_dns_client(ips_to_hosts: HashMap<IpAddr, String>) -> Option<dns::Client> {


### PR DESCRIPTION
## Synopsis

`OSInputOutput` definition changed from:
```rust
pub struct OsInputOutput {
    pub network_interfaces: Vec<NetworkInterface>,
    pub network_frames: Vec<Box<dyn DataLinkReceiver>>,
    pub get_open_sockets: fn() -> OpenSockets,
    pub terminal_events: Box<dyn Iterator<Item = Event> + Send>,
    pub dns_client: Option<dns::Client>,
    pub write_to_stdout: Box<dyn FnMut(String) + Send>,
}
```
to:
```rust
pub struct OsInputOutput {
    pub interfaces_with_frames: Vec<(NetworkInterface, Box<dyn DataLinkReceiver>)>,
    pub get_open_sockets: fn() -> OpenSockets,
    pub terminal_events: Box<dyn Iterator<Item = Event> + Send>,
    pub dns_client: Option<dns::Client>,
    pub write_to_stdout: Box<dyn FnMut(String) + Send>,
}
```

This is to provide stronger semantic safeguards against accidental & unnoticed screwups.

---

## Unresolved issues

- [x] <s>This refactor seems to have changed test outputs substantively, when it really shouldn't have changed anything. This needs to be investigated before merge.</s> Okay clearly not. That seems to be due to another commit on my local branch. This is good to merge then, seeing that the test failures are no worse than they were.