### PR TITLE
Show interface names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+* Show interface names #340 - @ilyes-ced
 * CI: ensure a changelog entry exists for each PR #331 - @cyqsimon
 
 ## [0.21.1] - 2023-10-16

--- a/src/display/components/header_details.rs
+++ b/src/display/components/header_details.rs
@@ -88,8 +88,8 @@ impl<'a> HeaderDetails<'a> {
             unit_family,
         };
         let paused = if self.paused { " [PAUSED]" } else { "" };
-        let intrf = &self.state.interface_name;
-        format!("Interface: <{intrf}> | Total {t} (Up / Down): {up} / {down}{paused}")
+        let intrf = self.state.interface_name.clone().unwrap_or("All".to_string());
+        format!("IF: {intrf} | Total {t} (Up / Down): {up} / {down}{paused}")
     }
 
     fn render_elapsed_time(&self, frame: &mut Frame, rect: Rect, elapsed_time: &str, color: Color) {

--- a/src/display/components/header_details.rs
+++ b/src/display/components/header_details.rs
@@ -88,7 +88,8 @@ impl<'a> HeaderDetails<'a> {
             unit_family,
         };
         let paused = if self.paused { " [PAUSED]" } else { "" };
-        format!(" Total {t} (Up / Down): {up} / {down}{paused}")
+        let intrf = &self.state.interface_name;
+        format!("Interface: <{intrf}> | Total {t} (Up / Down): {up} / {down}{paused}")
     }
 
     fn render_elapsed_time(&self, frame: &mut Frame, rect: Rect, elapsed_time: &str, color: Color) {

--- a/src/display/components/header_details.rs
+++ b/src/display/components/header_details.rs
@@ -73,6 +73,7 @@ impl<'a> HeaderDetails<'a> {
     }
 
     fn bandwidth_string(&self) -> String {
+        let intrf = self.state.interface_name.as_deref().unwrap_or("all");
         let t = if self.state.cumulative_mode {
             "Data"
         } else {
@@ -88,7 +89,6 @@ impl<'a> HeaderDetails<'a> {
             unit_family,
         };
         let paused = if self.paused { " [PAUSED]" } else { "" };
-        let intrf = self.state.interface_name.clone().unwrap_or("All".to_string());
         format!("IF: {intrf} | Total {t} (Up / Down): {up} / {down}{paused}")
     }
 

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -182,7 +182,7 @@ where
     pub fn end(&mut self) {
         self.terminal.show_cursor().unwrap();
     }
-    pub fn update_interface_name(&mut self, interface_name: String) {
+    pub fn update_interface_name(&mut self, interface_name: Option<String>) {
         self.state.interface_name = interface_name;
     }
 }

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use ratatui::{backend::Backend, Terminal};
 
 use crate::{
-    cli::RenderOpts,
+    cli::{Opt, RenderOpts},
     display::{
         components::{HeaderDetails, HelpText, Layout, Table},
         UIState,
@@ -26,21 +26,22 @@ impl<B> Ui<B>
 where
     B: Backend,
 {
-    pub fn new(terminal_backend: B, opts: RenderOpts) -> Self {
+    pub fn new(terminal_backend: B, opts: &Opt) -> Self {
         let mut terminal = Terminal::new(terminal_backend).unwrap();
         terminal.clear().unwrap();
         terminal.hide_cursor().unwrap();
         let state = {
             let mut state = UIState::default();
-            state.unit_family = opts.unit_family;
-            state.cumulative_mode = opts.total_utilization;
+            state.interface_name = opts.interface.clone();
+            state.unit_family = opts.render_opts.unit_family;
+            state.cumulative_mode = opts.render_opts.total_utilization;
             state
         };
         Ui {
             terminal,
             state,
             ip_to_host: Default::default(),
-            opts,
+            opts: opts.render_opts,
         }
     }
     pub fn output_text(&mut self, write_to_stdout: &mut (dyn FnMut(String) + Send)) {
@@ -181,8 +182,5 @@ where
     }
     pub fn end(&mut self) {
         self.terminal.show_cursor().unwrap();
-    }
-    pub fn update_interface_name(&mut self, interface_name: Option<String>) {
-        self.state.interface_name = interface_name;
     }
 }

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -182,4 +182,7 @@ where
     pub fn end(&mut self) {
         self.terminal.show_cursor().unwrap();
     }
+    pub fn update_interface_name(&mut self, interface_name: String) {
+        self.state.interface_name = interface_name;
+    }
 }

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -79,6 +79,8 @@ pub struct UtilizationData {
 
 #[derive(Default)]
 pub struct UIState {
+    /// The interface name in single-interface mode. `None` means all interfaces.
+    pub interface_name: Option<String>,
     pub processes: Vec<(String, NetworkData)>,
     pub remote_addresses: Vec<(IpAddr, NetworkData)>,
     pub connections: Vec<(Connection, ConnectionData)>,
@@ -92,7 +94,6 @@ pub struct UIState {
     pub connections_map: HashMap<Connection, ConnectionData>,
     /// Used for reducing logging noise.
     known_orphan_sockets: VecDeque<LocalSocket>,
-    pub interface_name: Option<String>,
 }
 
 impl UIState {

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -92,6 +92,7 @@ pub struct UIState {
     pub connections_map: HashMap<Connection, ConnectionData>,
     /// Used for reducing logging noise.
     known_orphan_sockets: VecDeque<LocalSocket>,
+    pub interface_name: String,
 }
 
 impl UIState {

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -92,7 +92,7 @@ pub struct UIState {
     pub connections_map: HashMap<Connection, ConnectionData>,
     /// Used for reducing logging noise.
     known_orphan_sockets: VecDeque<LocalSocket>,
-    pub interface_name: String,
+    pub interface_name: Option<String>,
 }
 
 impl UIState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,11 @@ where
                         let mut ui = ui.lock().unwrap();
                         let paused = paused.load(Ordering::SeqCst);
                         let ui_offset = ui_offset.load(Ordering::SeqCst);
+                        let interface = match opts.interface {
+                            Some(ref interface_name) => interface_name.to_string(),
+                            None => "All Interfaces".to_string(),
+                        };
+                        ui.update_interface_name(interface);
                         if !paused {
                             ui.update_state(sockets_to_procs, utilization, ip_to_host);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,11 +155,7 @@ where
                         let mut ui = ui.lock().unwrap();
                         let paused = paused.load(Ordering::SeqCst);
                         let ui_offset = ui_offset.load(Ordering::SeqCst);
-                        let interface = match opts.interface {
-                            Some(ref interface_name) => interface_name.to_string(),
-                            None => "All Interfaces".to_string(),
-                        };
-                        ui.update_interface_name(interface);
+                        ui.update_interface_name(opts.interface.clone());
                         if !paused {
                             ui.update_state(sockets_to_procs, utilization, ip_to_host);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ where
     let raw_mode = opts.raw;
 
     let network_utilization = Arc::new(Mutex::new(Utilization::new()));
-    let ui = Arc::new(Mutex::new(Ui::new(terminal_backend, opts.render_opts)));
+    let ui = Arc::new(Mutex::new(Ui::new(terminal_backend, &opts)));
 
     let display_handler = thread::Builder::new()
         .name("display_handler".to_string())
@@ -155,7 +155,6 @@ where
                         let mut ui = ui.lock().unwrap();
                         let paused = paused.load(Ordering::SeqCst);
                         let ui_offset = ui_offset.load(Ordering::SeqCst);
-                        ui.update_interface_name(opts.interface.clone());
                         if !paused {
                             ui.update_state(sockets_to_procs, utilization, ip_to_host);
                         }

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_only_addresses.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_only_addresses.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by remote address───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Remote Address                                                                                                Connections                      Rate (Up / Down)                             │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_only_connections.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_only_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Connection                                                                                                           Process                                Rate (Up / Down)                │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_only_processes.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_only_processes.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Process                                                                                    Connections                              Rate (Up / Down)                                        │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_processes_with_dns_queries.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_processes_with_dns_queries.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Process                                                                                    Connections                              Rate (Up / Down)                                        │
 │                                                                                                                                                                                            │

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_startup.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__basic_startup.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__bi_directional_traffic.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__bi_directional_traffic.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         24. 0B / 25.00B                                                                                                                                                      
+                                             24. 0B / 25.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    24.00B / 25.00B             1.1.1.1                                     1                 24.00B / 25.00B                 

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-full-width-under-30-height-draw_events.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-full-width-under-30-height-draw_events.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -33,7 +33,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 98. 0B                                                                                                                                                       
+                                                     98. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  5                                             1                    0.00B / 28.00B              3.3.3.3                                     1                 0.00B / 28.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-120-width-full-height-draw_events.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-120-width-full-height-draw_events.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                 
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                             
 ┌Utilization by process name──────────────────────────────────────────────────────────────────────────────────────────┐
 │Process                                                  Connections               Rate (Up / Down)                  │
 │                                                                                                                     │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                          
 
 --- SECTION SEPARATOR ---
-                                 98. 0B                                                                                
+                                                     98. 0B                                                            
                                                                                                                        
                                                                                                                        
  5                                                        1                         0.00B / 28.00B                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-120-width-under-30-height-draw_events.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-120-width-under-30-height-draw_events.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                 
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                             
 ┌Utilization by process name──────────────────────────────────────────────────────────────────────────────────────────┐
 │Process                                                  Connections               Rate (Up / Down)                  │
 │                                                                                                                     │
@@ -33,7 +33,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                          
 
 --- SECTION SEPARATOR ---
-                                 98. 0B                                                                                
+                                                     98. 0B                                                            
                                                                                                                        
                                                                                                                        
  5                                                        1                         0.00B / 28.00B                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-50-width-under-50-height-draw_events.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-50-width-under-50-height-draw_events.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B            
+IF: interface_name | Total Rate (Up / Down): 0.00B
 ┌Utilization by process name─────────────────────┐
 │Process                  Rate (Up / Down)       │
 │                                                │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause.                          
 
 --- SECTION SEPARATOR ---
-                                 98. 0B           
+                                                  
                                                   
                                                   
  5                        0.00B / 28.00B          

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-70-width-under-30-height-draw_events.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__layout-under-70-width-under-30-height-draw_events.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                               
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B           
 ┌Utilization by process name────────────────────────────────────────┐
 │Process                        Connections    Rate (Up / Down)     │
 │                                                                   │
@@ -33,7 +33,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables.              
 
 --- SECTION SEPARATOR ---
-                                 98. 0B                              
+                                                     98. 0B          
                                                                      
                                                                      
  5                              1              0.00B / 28.00B        

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_connections_from_remote_address.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_connections_from_remote_address.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 47. 0B                                                                                                                                                       
+                                                     47. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             2                    0.00B / 47.00B              1.1.1.1                                     2                 0.00B / 47.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_packets_of_traffic_from_different_connections.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_packets_of_traffic_from_different_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 41. 0B                                                                                                                                                       
+                                                     41. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 22.00B              2.2.2.2                                     2                 0.00B / 41.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_packets_of_traffic_from_single_connection.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_packets_of_traffic_from_single_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 45. 0B                                                                                                                                                       
+                                                     45. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 45.00B              1.1.1.1                                     1                 0.00B / 45.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_processes_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__multiple_processes_with_multiple_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 98. 0B                                                                                                                                                       
+                                                     98. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  5                                             1                    0.00B / 28.00B              3.3.3.3                                     1                 0.00B / 28.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__no_resolve_mode.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__no_resolve_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         45. 0B / 49.00B                                                                                                                                                      
+                                             45. 0B / 49.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    28.00B / 30.00B             1.1.1.1                                     1                 28.00B / 30.00B                 
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                         53       60                                                                                                                                                          
+                                             53       60                                                                                                                                      
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                     31        2                                                                               31        2                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__one_packet_of_traffic.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__one_packet_of_traffic.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         21. 0B / 0. 0B                                                                                                                                                       
+                                             21. 0B / 0. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    21.00B / 0.00B              1.1.1.1                                     1                 21.00B / 0.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__one_process_with_multiple_connections.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__one_process_with_multiple_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 46. 0B                                                                                                                                                       
+                                                     46. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             2                    0.00B / 46.00B              1.1.1.1                                     2                 0.00B / 46.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__pause_by_space.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__pause_by_space.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
- Total Rate (Up / Down): 0.00B / 0.00B [PAUSED]                                                                                                                                               
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B [PAUSED]                                                                                                                           
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                                                                                                                                               

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__rearranged_by_tab.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__rearranged_by_tab.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 22. 0B                                                                                                                                                       
+                                                     22. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 22.00B              1.1.1.1                                     1                 0.00B / 22.00B                  
@@ -158,7 +158,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                                 14                                                                                                                                                           
+                                                     14                                                                                                                                       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                        14                                                                                                      14             
@@ -210,7 +210,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                                  1                                                                                                                                                           
+                                                      1                                                                                                                                       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                         1                                                                                                       1             

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 41. 0B                                                                                                                                                       
+                                                     41. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 22.00B              1.1.1.1                                     1                 0.00B / 22.00B                  
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                                 65                                                                                                                                                           
+                                                     65                                                                                                                                       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                             35                                                                                        35                      

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes_bi_directional.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes_bi_directional.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         45. 0B / 49.00B                                                                                                                                                      
+                                             45. 0B / 49.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    28.00B / 30.00B             1.1.1.1                                     1                 28.00B / 30.00B                 
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                         53       60                                                                                                                                                          
+                                             53       60                                                                                                                                      
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                     31        2                                                                               31        2                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes_bi_directional_total.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes_bi_directional_total.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Data (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Data (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Data (Up / Down)          ││Remote Address                              Connections       Data (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         45. 0B / 49.00B                                                                                                                                                      
+                                             45. 0B / 49.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    28.00B / 30.00B             1.1.1.1                                     1                 28.00B / 30.00B                 
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                         98       109. 0B                                                                                                                                                     
+                                             98       109. 0B                                                                                                                                 
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                     59       62                                                                               59       62                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes_total.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_multiple_processes_total.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Data (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Data (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Data (Up / Down)          ││Remote Address                              Connections       Data (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 41. 0B                                                                                                                                                       
+                                                     41. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 22.00B              1.1.1.1                                     1                 0.00B / 22.00B                  
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                                 106. 0B                                                                                                                                                      
+                                                     106. 0B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                             57                                                                                        57                      

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_one_process.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_one_process.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 22. 0B                                                                                                                                                       
+                                                     22. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 22.00B              1.1.1.1                                     1                 0.00B / 22.00B                  
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                                 31                                                                                                                                                           
+                                                     31                                                                                                                                       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                             31                                                                                        31                      

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_one_process_total.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__sustained_traffic_from_one_process_total.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Data (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Data (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Data (Up / Down)          ││Remote Address                              Connections       Data (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                                 22. 0B                                                                                                                                                       
+                                                     22. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    0.00B / 22.00B              1.1.1.1                                     1                 0.00B / 22.00B                  
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                                 53                                                                                                                                                           
+                                                     53                                                                                                                                       
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                             53                                                                                        53                      

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__traffic_with_host_names.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__traffic_with_host_names.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         45. 0B / 49.00B                                                                                                                                                      
+                                             45. 0B / 49.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    28.00B / 30.00B             1.1.1.1                                     1                 28.00B / 30.00B                 
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                         53       60                                                                                                                                                          
+                                             53       60                                                                                                                                      
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                     31        2                 one one.one.one                                               31        2                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__traffic_with_winch_event.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__traffic_with_winch_event.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         21. 0B / 0. 0B                                                                                                                                                       
+                                             21. 0B / 0. 0B                                                                                                                                   
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    21.00B / 0.00B              1.1.1.1                                     1                 21.00B / 0.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__truncate_long_hostnames.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__truncate_long_hostnames.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name──────────────────────────────────────────────────────────────────┐┌Utilization by remote address────────────────────────────────────────────────────────────────┐
 │Process                                       Connections          Rate (Up / Down)          ││Remote Address                              Connections       Rate (Up / Down)               │
 │                                                                                             ││                                                                                             │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         45. 0B / 49.00B                                                                                                                                                      
+                                             45. 0B / 49.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                             1                    28.00B / 30.00B             1.1.1.1                                     1                 28.00B / 30.00B                 
@@ -106,7 +106,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
                                                                                                                                                                                               
 
 --- SECTION SEPARATOR ---
-                         53       60                                                                                                                                                          
+                                             53       60                                                                                                                                      
                                                                                                                                                                                               
                                                                                                                                                                                               
                                                                     31        2                 i am.not.too.long                                             31        2                     

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_packets_only_addresses.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_packets_only_addresses.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by remote address───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Remote Address                                                                                                Connections                      Rate (Up / Down)                             │
 │                                                                                                                                                                                            │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         24. 0B / 25.00B                                                                                                                                                      
+                                             24. 0B / 25.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1.1.1.1                                                                                                       1                                24.00B / 25.00B                               

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_packets_only_connections.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_packets_only_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by connection───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Connection                                                                                                           Process                                Rate (Up / Down)                │
 │                                                                                                                                                                                            │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         24. 0B / 25.00B                                                                                                                                                      
+                                             24. 0B / 25.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  <interface_name>:443 => 1.1.1.1:12345 (tcp)                                                                          1                                      24.00B / 25.00B                  

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_packets_only_processes.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_packets_only_processes.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by process name─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │Process                                                                                    Connections                              Rate (Up / Down)                                        │
 │                                                                                                                                                                                            │
@@ -54,7 +54,7 @@ expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR
  Press <SPACE> to pause. Use <TAB> to rearrange tables. (DNS queries hidden).                                                                                                                 
 
 --- SECTION SEPARATOR ---
-                         24. 0B / 25.00B                                                                                                                                                      
+                                             24. 0B / 25.00B                                                                                                                                  
                                                                                                                                                                                               
                                                                                                                                                                                               
  1                                                                                          1                                        24.00B / 25.00B                                          

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_windows_split_horizontally.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_windows_split_horizontally.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                      
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B  
 ┌Utilization by remote address─────────────────────────────┐
 │Remote Address                     Rate (Up / Down)       │
 │                                                          │

--- a/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_windows_split_vertically.snap
+++ b/src/tests/cases/snapshots/bandwhich__tests__cases__ui__two_windows_split_vertically.snap
@@ -2,7 +2,7 @@
 source: src/tests/cases/ui.rs
 expression: terminal_draw_events.lock().unwrap().join(SNAPSHOT_SECTION_SEPARATOR)
 ---
- Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                                        
+IF: interface_name | Total Rate (Up / Down): 0.00B / 0.00B                                                                                                                                    
 ┌Utilization by remote address────────────────────────────────────────────────────────────────┐┌Utilization by connection────────────────────────────────────────────────────────────────────┐
 │Remote Address                              Connections       Rate (Up / Down)               ││Connection                                           Process           Rate (Up / Down)      │
 │                                                                                             ││                                                                                             │


### PR DESCRIPTION
fixing old commits

solves issue #37 to some extent
unfortunately i wasn't able to figure out how to add the network interface type along side it's name