### PR TITLE
Add option to exclude IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Display bandwidth in different unit families #328 - @cyqsimon
 * CI: ensure a changelog entry exists for each PR #331 - @cyqsimon
 * Show interface names #340 - @ilyes-ced
+* Add option to exclude IPs #341 - @ilyes-ced
 
 ### Changed
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ pub struct Opt {
     /// exclude multiple ip addresses with <-e x.x.x.x -e y.y.y.y>
     pub excluded_ipv4: Option<Vec<Ipv4Addr>>,
 
-    #[arg(long)]
+    #[arg(short = 'E', long)]
     /// exclude ip addres with <-e x.x.x.x:zzzz>
     /// exclude multiple ip addresses and port with <-e x.x.x.x:zzzz -e y.y.y.y:zzzz>
     pub excluded_ipv4_port: Option<Vec<SocketAddrV4>>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,16 +18,16 @@ impl FromStr for HostFilter {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(ipv4) = s.parse() {
-            return Ok(HostFilter::Ipv4Addr(ipv4));
+            Ok(HostFilter::Ipv4Addr(ipv4))
         } else if let Ok(ipv6) = s.parse() {
-            return Ok(HostFilter::Ipv6Addr(ipv6));
+            Ok(HostFilter::Ipv6Addr(ipv6))
         } else if let Ok(socketv4) = s.parse() {
-            return Ok(HostFilter::SocketAddrV4(socketv4));
+            Ok(HostFilter::SocketAddrV4(socketv4))
         } else if let Ok(socketv6) = s.parse() {
-            return Ok(HostFilter::SocketAddrV6(socketv6));
+            Ok(HostFilter::SocketAddrV6(socketv6))
         } else {
             // might need validation
-            return Ok(HostFilter::Hostname(s.to_string()));
+            Ok(HostFilter::Hostname(s.to_string()))
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,7 @@
-use std::{net::Ipv4Addr, path::PathBuf};
+use std::{
+    net::{Ipv4Addr, SocketAddrV4},
+    path::PathBuf,
+};
 
 use clap::{Args, Parser};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
@@ -37,6 +40,16 @@ pub struct Opt {
     #[command(flatten)]
     #[derivative(Default(value = "Verbosity::new(0, 0)"))]
     pub verbosity: Verbosity<InfoLevel>,
+
+    #[arg(short, long)]
+    /// exclude ip addres with <-e x.x.x.x>
+    /// exclude multiple ip addresses with <-e x.x.x.x -e y.y.y.y>
+    pub excluded_ipv4: Option<Vec<Ipv4Addr>>,
+
+    #[arg(long)]
+    /// exclude ip addres with <-e x.x.x.x:zzzz>
+    /// exclude multiple ip addresses and port with <-e x.x.x.x:zzzz -e y.y.y.y:zzzz>
+    pub excluded_ipv4_port: Option<Vec<SocketAddrV4>>,
 
     #[command(flatten)]
     pub render_opts: RenderOpts,

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use ratatui::{backend::Backend, Terminal};
 
 use crate::{
-    cli::{Opt, RenderOpts, HostFilter},
+    cli::{HostFilter, Opt, RenderOpts},
     display::{
         components::{HeaderDetails, HelpText, Layout, Table},
         UIState,

--- a/src/display/ui.rs
+++ b/src/display/ui.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use ratatui::{backend::Backend, Terminal};
 
 use crate::{
-    cli::RenderOpts,
+    cli::{HostFilter, RenderOpts},
     display::{
         components::{HeaderDetails, HelpText, Layout, Table},
         UIState,
@@ -178,6 +178,9 @@ where
     ) {
         self.state.update(connections_to_procs, utilization);
         self.ip_to_host.extend(ip_to_host);
+    }
+    pub fn set_excluded(&mut self, ex: Option<Vec<HostFilter>>) {
+        self.state.excluded_ips = ex;
     }
     pub fn end(&mut self) {
         self.terminal.show_cursor().unwrap();

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -97,12 +97,11 @@ pub struct UIState {
 }
 
 impl UIState {
-        pub fn update(
+    pub fn update(
         &mut self,
         connections_to_procs: HashMap<LocalSocket, String>,
         mut network_utilization: Utilization,
     ) {
-        println!("{:?}", self.excluded_ips);
         if let Some(excluded_addresses) = &self.excluded_ips {
             for ex in excluded_addresses {
                 network_utilization.connections.retain(|k, _| {
@@ -139,7 +138,7 @@ impl UIState {
                                 true
                             }
                         }
-                        HostFilter::Hostname(name) => {
+                        HostFilter::Hostname(_name) => {
                             // not implemented yet
                             true
                         }

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -3,10 +3,11 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     hash::Hash,
     iter::FromIterator,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
 };
 
 use crate::{
+    cli::HostFilter,
     display::BandwidthUnitFamily,
     mt_log,
     network::{Connection, LocalSocket, Utilization},
@@ -92,14 +93,61 @@ pub struct UIState {
     pub connections_map: HashMap<Connection, ConnectionData>,
     /// Used for reducing logging noise.
     known_orphan_sockets: VecDeque<LocalSocket>,
+    pub excluded_ips: Option<Vec<HostFilter>>,
 }
 
 impl UIState {
-    pub fn update(
+        pub fn update(
         &mut self,
         connections_to_procs: HashMap<LocalSocket, String>,
-        network_utilization: Utilization,
+        mut network_utilization: Utilization,
     ) {
+        println!("{:?}", self.excluded_ips);
+        if let Some(excluded_addresses) = &self.excluded_ips {
+            for ex in excluded_addresses {
+                network_utilization.connections.retain(|k, _| {
+                    let ip_address = k.remote_socket.ip;
+                    let port = k.remote_socket.port;
+                    let socket = SocketAddr::new(ip_address, port);
+
+                    match ex {
+                        HostFilter::Ipv4Addr(ipaddr) => {
+                            if let IpAddr::V4(ipv4) = ip_address {
+                                &ipv4 != ipaddr
+                            } else {
+                                true
+                            }
+                        }
+                        HostFilter::Ipv6Addr(ipaddr) => {
+                            if let IpAddr::V6(ipv6) = ip_address {
+                                &ipv6 != ipaddr
+                            } else {
+                                true
+                            }
+                        }
+                        HostFilter::SocketAddrV4(socketaddr) => {
+                            if let SocketAddr::V4(socketv4) = socket {
+                                &socketv4 != socketaddr
+                            } else {
+                                true
+                            }
+                        }
+                        HostFilter::SocketAddrV6(socketaddr) => {
+                            if let SocketAddr::V6(socketv6) = socket {
+                                &socketv6 != socketaddr
+                            } else {
+                                true
+                            }
+                        }
+                        HostFilter::Hostname(name) => {
+                            // not implemented yet
+                            true
+                        }
+                    }
+                });
+            }
+        }
+
         self.utilization_data.push_back(UtilizationData {
             connections_to_procs,
             network_utilization,

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,13 +138,7 @@ where
             move || {
                 while running.load(Ordering::Acquire) {
                     let render_start_time = Instant::now();
-                    let mut utilization = { network_utilization.lock().unwrap().clone_and_reset() };
-                    if let Some(ref ex) = opts.excluded_ipv4 {
-                        utilization.remove_ip(ex)
-                    }
-                    if let Some(ref ex) = opts.excluded_ipv4_port {
-                        utilization.remove_ip_port(ex)
-                    }
+                    let utilization = { network_utilization.lock().unwrap().clone_and_reset() };
                     let OpenSockets { sockets_to_procs } = get_open_sockets();
                     let mut ip_to_host = IpTable::new();
                     if let Some(dns_client) = dns_client.as_mut() {
@@ -161,6 +155,7 @@ where
                         let mut ui = ui.lock().unwrap();
                         let paused = paused.load(Ordering::SeqCst);
                         let ui_offset = ui_offset.load(Ordering::SeqCst);
+                        ui.set_excluded(opts.excluded.clone());
                         if !paused {
                             ui.update_state(sockets_to_procs, utilization, ip_to_host);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,14 +139,12 @@ where
                 while running.load(Ordering::Acquire) {
                     let render_start_time = Instant::now();
                     let mut utilization = { network_utilization.lock().unwrap().clone_and_reset() };
-                    match opts.excluded_ipv4 {
-                        Some(ref ex) => utilization.remove_ip(ex),
-                        None => {}
-                    };
-                    match opts.excluded_ipv4_port {
-                        Some(ref ex) => utilization.remove_ip_port(ex),
-                        None => {}
-                    };
+                    if let Some(ref ex) = opts.excluded_ipv4 {
+                        utilization.remove_ip(ex)
+                    }
+                    if let Some(ref ex) = opts.excluded_ipv4_port {
+                        utilization.remove_ip_port(ex)
+                    }
                     let OpenSockets { sockets_to_procs } = get_open_sockets();
                     let mut ip_to_host = IpTable::new();
                     if let Some(dns_client) = dns_client.as_mut() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,15 @@ where
             move || {
                 while running.load(Ordering::Acquire) {
                     let render_start_time = Instant::now();
-                    let utilization = { network_utilization.lock().unwrap().clone_and_reset() };
+                    let mut utilization = { network_utilization.lock().unwrap().clone_and_reset() };
+                    match opts.excluded_ipv4 {
+                        Some(ref ex) => utilization.remove_ip(ex),
+                        None => {}
+                    };
+                    match opts.excluded_ipv4_port {
+                        Some(ref ex) => utilization.remove_ip_port(ex),
+                        None => {}
+                    };
                     let OpenSockets { sockets_to_procs } = get_open_sockets();
                     let mut ip_to_host = IpTable::new();
                     if let Some(dns_client) = dns_client.as_mut() {

--- a/src/network/utilization.rs
+++ b/src/network/utilization.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    net::{Ipv4Addr, SocketAddrV4},
-};
+use std::collections::HashMap;
 
 use crate::network::{Connection, Direction, Segment};
 
@@ -42,38 +39,6 @@ impl Utilization {
             }
             Direction::Upload => {
                 total_bandwidth.total_bytes_uploaded += seg.data_length;
-            }
-        }
-    }
-    pub fn remove_ip(&mut self, ips: &[Ipv4Addr]) {
-        // might be possible to refactor this part better
-        // i still don't understand the whole borrow/own system very well yet
-        let placeholder = self.connections.clone();
-        for util in placeholder {
-            match util.0.remote_socket.ip {
-                std::net::IpAddr::V4(ip) => {
-                    if ips.contains(&ip) {
-                        self.connections.remove_entry(&util.0);
-                    }
-                }
-                std::net::IpAddr::V6(..) => { /* nothing here yet (maybe implement it for ipV6 too) */
-                }
-            }
-        }
-    }
-    pub fn remove_ip_port(&mut self, ips: &[SocketAddrV4]) {
-        // might be possible to refactor this part better
-        // i still don't understand the whole borrow/own system very well yet
-        let placeholder = self.connections.clone();
-        for util in placeholder {
-            match util.0.remote_socket.ip {
-                std::net::IpAddr::V4(ip) => {
-                    if ips.contains(&SocketAddrV4::new(ip, util.0.remote_socket.port)) {
-                        self.connections.remove_entry(&util.0);
-                    }
-                }
-                std::net::IpAddr::V6(..) => { /* nothing here yet (maybe implement it for ipV6 too) */
-                }
             }
         }
     }

--- a/src/network/utilization.rs
+++ b/src/network/utilization.rs
@@ -45,7 +45,7 @@ impl Utilization {
             }
         }
     }
-    pub fn remove_ip(&mut self, ips: &Vec<Ipv4Addr>) {
+    pub fn remove_ip(&mut self, ips: &[Ipv4Addr]) {
         // might be possible to refactor this part better
         // i still don't understand the whole borrow/own system very well yet
         let placeholder = self.connections.clone();
@@ -61,7 +61,7 @@ impl Utilization {
             }
         }
     }
-    pub fn remove_ip_port(&mut self, ips: &Vec<SocketAddrV4>) {
+    pub fn remove_ip_port(&mut self, ips: &[SocketAddrV4]) {
         // might be possible to refactor this part better
         // i still don't understand the whole borrow/own system very well yet
         let placeholder = self.connections.clone();

--- a/src/network/utilization.rs
+++ b/src/network/utilization.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddrV4},
+};
 
 use crate::network::{Connection, Direction, Segment};
 
@@ -39,6 +42,38 @@ impl Utilization {
             }
             Direction::Upload => {
                 total_bandwidth.total_bytes_uploaded += seg.data_length;
+            }
+        }
+    }
+    pub fn remove_ip(&mut self, ips: &Vec<Ipv4Addr>) {
+        // might be possible to refactor this part better
+        // i still don't understand the whole borrow/own system very well yet
+        let placeholder = self.connections.clone();
+        for util in placeholder {
+            match util.0.remote_socket.ip {
+                std::net::IpAddr::V4(ip) => {
+                    if ips.contains(&ip) {
+                        self.connections.remove_entry(&util.0);
+                    }
+                }
+                std::net::IpAddr::V6(..) => { /* nothing here yet (maybe implement it for ipV6 too) */
+                }
+            }
+        }
+    }
+    pub fn remove_ip_port(&mut self, ips: &Vec<SocketAddrV4>) {
+        // might be possible to refactor this part better
+        // i still don't understand the whole borrow/own system very well yet
+        let placeholder = self.connections.clone();
+        for util in placeholder {
+            match util.0.remote_socket.ip {
+                std::net::IpAddr::V4(ip) => {
+                    if ips.contains(&SocketAddrV4::new(ip, util.0.remote_socket.port)) {
+                        self.connections.remove_entry(&util.0);
+                    }
+                }
+                std::net::IpAddr::V6(..) => { /* nothing here yet (maybe implement it for ipV6 too) */
+                }
             }
         }
     }


### PR DESCRIPTION
fixing old PR

solves issue #283
adds possibility to exclude an ip address x.x.x.x or an ip address with a port x.x.x.x:xxxx
can also exclude multiple ips at the same time with `bandwitch -e x.x.x.x -e y.y.y.y  --excluded-ipv4-port z.z.z.z:zzzz`