### PR TITLE
CI: strip release binaries for all targets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,11 +83,9 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends musl-tools
 
       - name: Build release binary
+        env:
+          RUSTFLAGS: "-C strip=symbols"
         run: cargo build --verbose --release --target ${{ matrix.target }}
-
-      - name: Strip release binary (unix)
-        if: matrix.os != 'windows-latest'
-        run: strip "target/${{ matrix.target }}/release/bandwhich"
 
       - name: Tar release (unix)
         if: matrix.os != 'windows-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## Changed
+* CI: strip release binaries for all targets #358 - @cyqsimon
+
 ## [0.22.2] - 2024-01-28
 
 ## Added


### PR DESCRIPTION
- This is now done using `rustc` flags directly