### PR TITLE
Remove redundant imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## Fixed
+* Remove redundant imports #377 - @cyqsimon
+
 ## Added
 * CI: include generated assets in release archive #359 - @cyqsimon
 

--- a/build.rs
+++ b/build.rs
@@ -39,12 +39,10 @@ fn build_completion_manpage() -> anyhow::Result<()> {
 #[cfg(target_os = "windows")]
 fn download_windows_npcap_sdk() -> anyhow::Result<()> {
     use std::{
-        env, fs,
+        fs,
         io::{self, Write},
-        path::PathBuf,
     };
 
-    use anyhow::anyhow;
     use http_req::request;
     use zip::ZipArchive;
 

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, iter::FromIterator, net::IpAddr, ops::Index, rc::Rc};
+use std::{collections::HashMap, fmt, net::IpAddr, ops::Index, rc::Rc};
 
 use derivative::Derivative;
 use itertools::Itertools;

--- a/src/display/ui_state.rs
+++ b/src/display/ui_state.rs
@@ -2,7 +2,6 @@ use std::{
     cmp,
     collections::{HashMap, HashSet, VecDeque},
     hash::Hash,
-    iter::FromIterator,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 


### PR DESCRIPTION
- Now linted by clippy in 1.78
- See https://github.com/rust-lang/rust/pull/117772