### PR TITLE
Enable Android build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,12 +47,24 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
+      - name: Install Cross on Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        # The latest realese of `cross` is not able to build/link for `aarch64-linux-android`
+        # See: https://github.com/cross-rs/cross/issues/1222
+        # This is fixed on `main` but not yet released. To avoid a breakage somewhen in the future
+        # pin the cross revision used to the latest HEAD at 04/2024. 
+        # Remove the git source and revision once cross 0.3 is released.
+        run: cargo install --git https://github.com/cross-rs/cross.git --rev 085092c cross
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Build
-        id: build
         run: cargo build --verbose
+
+      - name: Build target aarch64-linux-android
+        if: matrix.os == 'ubuntu-latest'
+        run: cross build --target aarch64-linux-android --verbose
 
       # This is useful for debugging problems when the expected build artifacts
       # (like shell completions and man pages) aren't generated.
@@ -102,6 +114,13 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.rust }}-failed_snapshots
           path: '**/*.snap.new'
+
+      - name: Upload android binary
+        if: ${{ matrix.os == 'ubuntu-latest' && ( success() || steps.build.outcome == 'success' ) }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: aarch64-linux-android-${{ matrix.rust }}
+          path: target/aarch64-linux-android/debug/bandwhich
 
       - name: Upload unix binary
         if: ${{ matrix.os != 'windows-latest' && ( success() || steps.build.outcome == 'success' ) }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,11 +52,17 @@ jobs:
     strategy:
       matrix:
         build:
+          - aarch64-linux-android
           - linux-x64-gnu
           - linux-x64-musl
           - macos-x64
           - windows-x64-msvc
         include:
+          - cargo: cargo # default; overwrite with `cross` if necessary
+          - build: aarch64-linux-android
+            os: ubuntu-latest
+            target: aarch64-linux-android
+            cargo: cross
           - build: linux-x64-gnu
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -84,13 +90,17 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y --no-install-recommends musl-tools
 
+      - name: Install cross
+        if: matrix.cargo == 'cross'
+        run: cargo install --git https://github.com/cross-rs/cross.git --rev 085092c cross
+
       - name: Build release binary
         shell: bash
         env:
           RUSTFLAGS: "-C strip=symbols"
         run: |
           mkdir -p "$BANDWHICH_GEN_DIR"
-          cargo build --verbose --release --target ${{ matrix.target }}
+          ${{ matrix.cargo }} build --verbose --release --target ${{ matrix.target }}
 
       - name: Collect build artifacts
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ## Fixed
+
 * Remove redundant imports #377 - @cyqsimon
 * CI: use GitHub API to exempt dependabot from changelog requirement #378 - @cyqsimon
 * Remove unnecessary logging synchronisation #381 - @cyqsimon
@@ -15,10 +16,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Support build for `target_os`` `android` #384 - @flxo
 
 ## Added
+
 * CI: include generated assets in release archive #359 - @cyqsimon
 * Add PID column to the process table #379 - @notjedi
+* CI: add builds for target `aarch64-linux-android` #384 - @flxo
 
 ## Changed
+
 * CI: strip release binaries for all targets #358 - @cyqsimon
 * Bump MSRV to 1.74 (required by clap 4.5; see #373)
 * CI: Configure dependabot grouping #395 - @cyqsimon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Remove unnecessary logging synchronisation #381 - @cyqsimon
 * Apply suggestions from new clippy lint clippy::assigning_clones #382 - @cyqsimon
 * Fix IPv6 socket detect logic #383 - @cyqsimon
+* Support build for `target_os`` `android` #384 - @flxo
 
 ## Added
 * CI: include generated assets in release archive #359 - @cyqsimon

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ trust-dns-resolver = "0.23.2"
 unicode-width = "0.1.11"
 strum = { version = "0.26.2", features = ["derive"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 procfs = "0.16.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For more details, see [The Future of Bandwhich #275](https://github.com/imsnif/b
 
 ### Download a prebuilt binary
 
-If you're on linux, you can download the generic binary from the releases.
+If you're on `android` or `linux`, you can download the generic binary from the [releases](https://github.com/imsnif/bandwhich/releases)
 
 ### Arch Linux
 
@@ -122,6 +122,19 @@ The minimum supported Rust version is **1.70.0**.
 ```
 cargo install bandwhich
 ```
+
+#### Building from source for Android (`aarch64-linux-android`)
+
+Building for target `aarch64-linux-android` is supported via [cross](https://github.com/cross-rs/cross). Until [#1222](https://github.com/cross-rs/cross/issues/1222) is solved, use the latest HEAD:
+
+```sh
+cargo install --git https://github.com/cross-rs/cross.git cross
+cross build --release --target aarch64-linux-android
+```
+
+Kindly be aware that this process generates a pure binary file and not an APK suitable for installation on any arbitrary Android device.
+
+The Android support for bandwhich beyond its build is *not* endorsed by this project and may be unstable or non-functional.
 
 ### OpenWRT
 

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux;
 
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Runtime;
 
 use crate::{network::dns, os::errors::GetInterfaceError, OsInputOutput};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use crate::os::linux::get_open_sockets;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 use crate::os::lsof::get_open_sockets;
@@ -220,7 +220,7 @@ fn eperm_message() -> &'static str {
 }
 
 #[inline]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 fn eperm_message() -> &'static str {
     r#"
     Insufficient permissions to listen on network interface(s). You can work around


### PR DESCRIPTION
The target_os `android` is quite similar to `linux` but must be mentioned in the guards explicitly. Tested on a headless Android 9 with resolving disabled.

Fixes #78 