### PR TITLE
Temporarily disable UI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
           done
 
       - name: Run clippy
-        run: ${{ matrix.cargo }} clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
+        run: ${{ matrix.cargo }} clippy --all-targets --target ${{ matrix.target }} -- -D warnings
 
       - name: Install npcap on Windows
         # PRs from other repositories cannot be trusted with repository secrets
@@ -145,7 +145,7 @@ jobs:
         env:
           # make insta generate new snapshots in CI
           INSTA_UPDATE: new
-        run: ${{ matrix.cargo }} test --all-targets --all-features --target ${{ matrix.target }}
+        run: ${{ matrix.cargo }} test --all-targets --target ${{ matrix.target }}
 
       - name: Upload snapshots of failed tests
         if: ${{ failure() && steps.run_tests.outcome == 'failure' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Bump MSRV to 1.74 (required by clap 4.5; see #373)
 * CI: Configure dependabot grouping #395 - @cyqsimon
 * CI refactor #399 - @cyqsimon
+* CI: Temporarily disable UI tests #406 - @cyqsimon
 
 ## Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ repository = "https://github.com/imsnif/bandwhich"
 rust-version = "1.74.0"
 description = "Display current network utilization by process, connection and remote IP/hostname"
 
+[features]
+default = []
+# UI tests temporarily disabled by default, until big refactor is done
+ui_test = []
+
 [dependencies]
 anyhow = { version = "1.0.82", features = ["backtrace"] }
 async-trait = "0.1.80"

--- a/src/tests/cases/mod.rs
+++ b/src/tests/cases/mod.rs
@@ -1,3 +1,4 @@
 pub mod raw_mode;
 pub mod test_utils;
+#[cfg(feature = "ui_test")]
 pub mod ui;

--- a/src/tests/cases/test_utils.rs
+++ b/src/tests/cases/test_utils.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "ui_test"), allow(dead_code))]
+
 use std::{
     collections::HashMap,
     io::Write,


### PR DESCRIPTION
- Too many sporadic errors occlude actual problems; see #400
- These tests will be re-enabled once the big refactor is complete