### PR TITLE
Fix breaking changes of `sysinfo` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * CI: Use Powershell Compress-Archive to create Windows binary zip #424 - @cyqsimon
 * Exit gracefully when there is a broken pipe error #429 - @sigmaSd
+* Fix breaking changes of sysinfo crate #431 - @cyqsimon
 
 ## [0.23.0] - 2024-08-17
 

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -13,7 +13,7 @@ pub(crate) fn get_open_sockets() -> OpenSockets {
     let mut open_sockets = HashMap::new();
 
     let mut sysinfo = System::new_all();
-    sysinfo.refresh_processes(ProcessesToUpdate::All);
+    sysinfo.refresh_processes(ProcessesToUpdate::All, true);
 
     let af_flags = AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
     let proto_flags = ProtocolFlags::TCP | ProtocolFlags::UDP;


### PR DESCRIPTION
I neglected to check Windows-specific modules in #430.