### PR TITLE
Fix `clippy::needless_lifetimes` warnings on nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * CI: Use Powershell Compress-Archive to create Windows binary zip #424 - @cyqsimon
 * Exit gracefully when there is a broken pipe error #429 - @sigmaSd
 * Fix breaking changes of sysinfo crate #431 - @cyqsimon
+* Fix `clippy::needless_lifetimes` warnings on nightly #432 - @cyqsimon
 
 ## [0.23.0] - 2024-08-17
 

--- a/src/display/components/header_details.rs
+++ b/src/display/components/header_details.rs
@@ -40,7 +40,7 @@ pub struct HeaderDetails<'a> {
     pub paused: bool,
 }
 
-impl<'a> HeaderDetails<'a> {
+impl HeaderDetails<'_> {
     pub fn render(&self, frame: &mut Frame, rect: Rect) {
         let bandwidth = self.bandwidth_string();
         let color = if self.paused {

--- a/src/display/components/layout.rs
+++ b/src/display/components/layout.rs
@@ -30,7 +30,7 @@ pub struct Layout<'a> {
     pub footer: HelpText,
 }
 
-impl<'a> Layout<'a> {
+impl Layout<'_> {
     fn progressive_split(&self, rect: Rect, splits: Vec<Direction>) -> Vec<Rect> {
         splits
             .into_iter()


### PR DESCRIPTION
The warnings in `derivative`'s derived code are not something we can fix.