### PR TITLE
Add build optimizations for release binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Exit gracefully when there is a broken pipe error #429 - @sigmaSd
 * Fix breaking changes of sysinfo crate #431 - @cyqsimon
 * Fix `clippy::needless_lifetimes` warnings on nightly #432 - @cyqsimon
+
+### Changed
+
 * Add build optimizations for release binary #434 - @pando85
 
 ## [0.23.0] - 2024-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Exit gracefully when there is a broken pipe error #429 - @sigmaSd
 * Fix breaking changes of sysinfo crate #431 - @cyqsimon
 * Fix `clippy::needless_lifetimes` warnings on nightly #432 - @cyqsimon
+* Add build optimizations for release binary #434 - @pando85
 
 ## [0.23.0] - 2024-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,10 @@ strum = { version = "0.26.3", features = ["derive"] }
 [target.'cfg(target_os = "windows")'.build-dependencies]
 http_req = "0.12.0"
 zip = "2.2.0"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = "fat"
+panic = "abort"
+strip = "symbols"


### PR DESCRIPTION
I realized that you don't have any profile for the release build. I don't know if this is intended but I will share with you my current settings for optimizing CPU usage, this affects compilation times.

If you didn't optimize on purpose, sorry for the PR and feel free to close it fast. 

Source: https://nnethercote.github.io/perf-book/build-configuration.html