### PR TITLE
change derivative to reduce to fix clippy issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ After tests, check the formatting: `cargo fmt -- --check`
 
 Note that at the moment the tests do not test the os layer (anything in the `os` folder).
 
-If you are stuck, unsure about how to approach an issue or would like some guidance, you are welcome to contact: aram@poor.dev
+If you are stuck, unsure about how to approach an issue or would like some guidance, you are welcome to [open an issue](https://github.com/imsnif/bandwhich/issues/new);

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "crossterm",
- "derivative",
+ "educe",
  "http_req",
  "insta",
  "ipnetwork",
@@ -550,17 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +594,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +624,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ chrono = "0.4"
 clap-verbosity-flag = "2.2.2"
 clap = { version = "4.5.19", features = ["derive"] }
 crossterm = "0.28.1"
-derivative = "2.2.0"
 ipnetwork = "0.20.0"
 itertools = "0.13.0"
 log = "0.4.22"
@@ -47,6 +46,7 @@ tokio = { version = "1.40", features = ["rt", "sync"] }
 trust-dns-resolver = "0.23.2"
 unicode-width = "0.2.0"
 strum = { version = "0.26.3", features = ["derive"] }
+educe = { version = "0.6.0", default-features = false, features = ["Debug","Default"] }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 procfs = "0.17.0"
@@ -71,8 +71,9 @@ clap = { version = "4.5.19", features = ["derive"] }
 clap-verbosity-flag = "2.2.2"
 clap_complete = "4.5.32"
 clap_mangen = "0.2.23"
-derivative = "2.2.0"
 strum = { version = "0.26.3", features = ["derive"] }
+educe = { version = "0.6.0", default-features = false, features = ["Debug","Default"] }
+
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 http_req = "0.12.0"
@@ -84,3 +85,4 @@ opt-level = 3
 lto = "fat"
 panic = "abort"
 strip = "symbols"
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,11 +2,11 @@ use std::{net::Ipv4Addr, path::PathBuf};
 
 use clap::{Args, Parser, ValueEnum, ValueHint};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
-use derivative::Derivative;
+use educe::Educe;
 use strum::EnumIter;
 
-#[derive(Clone, Debug, Derivative, Parser)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Educe, Parser)]
+#[educe(Default)]
 #[command(name = "bandwhich", version)]
 pub struct Opt {
     #[arg(short, long)]
@@ -34,7 +34,7 @@ pub struct Opt {
     pub log_to: Option<PathBuf>,
 
     #[command(flatten)]
-    #[derivative(Default(value = "Verbosity::new(0, 0)"))]
+    #[educe(Default(expression = Verbosity::new(0, 0)))]
     pub verbosity: Verbosity<InfoLevel>,
 
     #[command(flatten)]

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 
-use derivative::Derivative;
+use educe::Educe;
 
 use crate::cli::UnitFamily;
 
-#[derive(Copy, Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Copy, Clone, Educe)]
+#[educe(Debug)]
 pub struct DisplayBandwidth {
-    #[derivative(Debug(format_with = "fmt_f64"))]
+    #[educe(Debug(method(fmt_f64)))]
     pub bandwidth: f64,
     pub unit_family: BandwidthUnitFamily,
 }
@@ -28,9 +28,15 @@ fn fmt_f64(val: &f64, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
 }
 
 /// Type wrapper around [`UnitFamily`] to provide extra functionality.
-#[derive(Copy, Clone, Derivative, Default, Eq, PartialEq)]
-#[derivative(Debug = "transparent")]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
 pub struct BandwidthUnitFamily(UnitFamily);
+
+impl std::fmt::Debug for BandwidthUnitFamily {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(fmt, "{:?}", self.0)
+    }
+}
+
 impl From<UnitFamily> for BandwidthUnitFamily {
     fn from(value: UnitFamily) -> Self {
         Self(value)

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt, net::IpAddr, ops::Index, rc::Rc};
 
-use derivative::Derivative;
+use educe::Educe;
 use itertools::Itertools;
 use ratatui::{
     layout::{Constraint, Rect},
@@ -165,8 +165,8 @@ impl TableData {
 ///
 /// Note that the number of columns here is independent of the number of columns
 /// being actually shown. If width-constrained, we might only show some of the columns.
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Educe)]
+#[educe(Debug)]
 struct NColsTableData<const C: usize> {
     /// The name of each column.
     column_names: [&'static str; C],
@@ -176,7 +176,7 @@ struct NColsTableData<const C: usize> {
     ///
     /// This function should return a vector of column indices.
     /// The indices should be less than `C`; otherwise this will cause a runtime panic.
-    #[derivative(Debug(format_with = "debug_fn::<C>"))]
+    #[educe(Debug(method(debug_fn::<C>)))]
     column_selector: Rc<ColumnSelectorFn>,
 }
 


### PR DESCRIPTION
ref https://github.com/imsnif/bandwhich/issues/303#issuecomment-2400213989

This changes `derivative` to `educe` with the intention of fixing clippy failures.

Unfortunately I *had* to manually implement a `Debug` at one place to maintain the formatting as educe does not have equivalent to derivative's `transparent` option. It seems like we have switched one unmaintained crate to another almost unmaintained crate :upside_down_face: . Atleast `educe` is more up-to-date and should fix the clippy. I checked few other options, but `educe` is by far the most compatible with `derivative` in terms of options.

Also changed `CONTRIBUTING` to mention opening an issue instead of mailing imsnif , as that seems more appropriate now.