### PR TITLE
replace derivative crate with derive_more crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+* Bump msrv to 1.75.0 #439 - @YJDoc2
+* Replace `derivative` with `derive_more` #439 - @YJDoc2
 * Add build optimizations for release binary #434 - @pando85
 * Minor cleanup and optimisations #435 - @cyqsimon
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "crossterm",
- "derivative",
+ "derive_more",
  "http_req",
  "insta",
  "ipnetwork",
@@ -550,17 +550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +569,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2212,6 +2222,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["networking", "utilization", "cli"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/imsnif/bandwhich"
-rust-version = "1.74.0"
+rust-version = "1.75.0"
 description = "Display current network utilization by process, connection and remote IP/hostname"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ chrono = "0.4"
 clap-verbosity-flag = "2.2.2"
 clap = { version = "4.5.19", features = ["derive"] }
 crossterm = "0.28.1"
-derivative = "2.2.0"
 ipnetwork = "0.20.0"
 itertools = "0.13.0"
 log = "0.4.22"
@@ -47,6 +46,7 @@ tokio = { version = "1.40", features = ["rt", "sync"] }
 trust-dns-resolver = "0.23.2"
 unicode-width = "0.2.0"
 strum = { version = "0.26.3", features = ["derive"] }
+derive_more = {version = "1.0.0", features = ["debug"]}
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 procfs = "0.17.0"
@@ -71,7 +71,7 @@ clap = { version = "4.5.19", features = ["derive"] }
 clap-verbosity-flag = "2.2.2"
 clap_complete = "4.5.32"
 clap_mangen = "0.2.23"
-derivative = "2.2.0"
+derive_more = {version = "1.0.0", features = ["debug"]}
 strum = { version = "0.26.3", features = ["derive"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,11 +2,10 @@ use std::{net::Ipv4Addr, path::PathBuf};
 
 use clap::{Args, Parser, ValueEnum, ValueHint};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
-use derivative::Derivative;
+use derive_more::Debug;
 use strum::EnumIter;
 
-#[derive(Clone, Debug, Derivative, Parser)]
-#[derivative(Default)]
+#[derive(Clone, Debug, Parser, Default)]
 #[command(name = "bandwhich", version)]
 pub struct Opt {
     #[arg(short, long)]
@@ -34,7 +33,6 @@ pub struct Opt {
     pub log_to: Option<PathBuf>,
 
     #[command(flatten)]
-    #[derivative(Default(value = "Verbosity::new(0, 0)"))]
     pub verbosity: Verbosity<InfoLevel>,
 
     #[command(flatten)]

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -1,13 +1,13 @@
+use crate::cli::UnitFamily;
+use derive_more::Debug;
 use std::fmt;
 
-use derivative::Derivative;
-
-use crate::cli::UnitFamily;
-
-#[derive(Copy, Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct DisplayBandwidth {
-    #[derivative(Debug(format_with = "fmt_f64"))]
+    // Custom format for reduced precision.
+    // Workaround for FP calculation discrepancy between Unix and Windows.
+    // See https://github.com/rust-lang/rust/issues/111405#issuecomment-2055964223.
+    #[debug("{bandwidth:.10e}")]
     pub bandwidth: f64,
     pub unit_family: BandwidthUnitFamily,
 }
@@ -19,17 +19,9 @@ impl fmt::Display for DisplayBandwidth {
     }
 }
 
-/// Custom formatter with reduced precision.
-///
-/// Workaround for FP calculation discrepancy between Unix and Windows.
-/// See https://github.com/rust-lang/rust/issues/111405#issuecomment-2055964223.
-fn fmt_f64(val: &f64, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-    write!(f, "{val:.10e}")
-}
-
 /// Type wrapper around [`UnitFamily`] to provide extra functionality.
-#[derive(Copy, Clone, Derivative, Default, Eq, PartialEq)]
-#[derivative(Debug = "transparent")]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[debug("{_0:?}")]
 pub struct BandwidthUnitFamily(UnitFamily);
 impl From<UnitFamily> for BandwidthUnitFamily {
     fn from(value: UnitFamily) -> Self {

--- a/src/display/components/display_bandwidth.rs
+++ b/src/display/components/display_bandwidth.rs
@@ -1,6 +1,8 @@
-use crate::cli::UnitFamily;
-use derive_more::Debug;
 use std::fmt;
+
+use derive_more::Debug;
+
+use crate::cli::UnitFamily;
 
 #[derive(Copy, Clone, Debug)]
 pub struct DisplayBandwidth {

--- a/src/display/components/table.rs
+++ b/src/display/components/table.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, fmt, net::IpAddr, ops::Index, rc::Rc};
+use std::{collections::HashMap, net::IpAddr, ops::Index, rc::Rc};
 
-use derivative::Derivative;
+use derive_more::Debug;
 use itertools::Itertools;
 use ratatui::{
     layout::{Constraint, Rect},
@@ -165,8 +165,7 @@ impl TableData {
 ///
 /// Note that the number of columns here is independent of the number of columns
 /// being actually shown. If width-constrained, we might only show some of the columns.
-#[derive(Clone, Derivative)]
-#[derivative(Debug)]
+#[derive(Clone, Debug)]
 struct NColsTableData<const C: usize> {
     /// The name of each column.
     column_names: [&'static str; C],
@@ -176,19 +175,12 @@ struct NColsTableData<const C: usize> {
     ///
     /// This function should return a vector of column indices.
     /// The indices should be less than `C`; otherwise this will cause a runtime panic.
-    #[derivative(Debug(format_with = "debug_fn::<C>"))]
+    #[debug("Rc</* function pointer */>")]
     column_selector: Rc<ColumnSelectorFn>,
 }
 
 /// Clippy wanted me to write this. 💢
 type ColumnSelectorFn = dyn Fn(&DisplayLayout) -> Vec<usize>;
-
-fn debug_fn<const C: usize>(
-    _func: &Rc<ColumnSelectorFn>,
-    f: &mut fmt::Formatter,
-) -> Result<(), fmt::Error> {
-    write!(f, "Rc</* function pointer */>")
-}
 
 /// A table displayed by bandwhich.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This PR carries over from https://github.com/imsnif/bandwhich/pull/437 and changes the `derivative` crate to the `derive_more` crate. This is particularly for the `Debug` derives which were bandwhich's main usecase for `derivative` .

- Removed `debug_fn` (formatting fn) in code, as it only adds a fixed string, so directly used that string in the macro.
- Used Rust's normal `Default` derive, as our main use case for it was setting the default of `Verbosity` . But `Verbosity` itself is a simple struct having two `u8` fields and a `PhantomData` , which also does a `derive(Default)` as the default for `u8` is 0, the "normal" Default should be same as `Verbosity::new(0, 0)` .