### PR TITLE
Fix confusing error message on macOS when running without sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+* Fix confusing error message on macOS when running without sudo #492 - @chiranjeevi-max
 * Fix Ctrl+C handling to use SIGINT signal instead of keypress #491 - @chiranjeevi-max
 * Update CONTRIBUTING information #438 - @YJDoc2 @cyqsimon
 * Fix new clippy lint #457 - @cyqsimon

--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -76,6 +76,13 @@ pub(crate) fn get_datalink_channel(
             ErrorKind::PermissionDenied => Err(GetInterfaceError::PermissionError(
                 interface.name.to_owned(),
             )),
+            // on macOS/FreeBSD, permission errors when opening BPF devices manifest as
+            // "No such file or directory" (ENOENT) rather than EPERM
+            // see https://github.com/imsnif/bandwhich/issues/486
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            ErrorKind::NotFound => Err(GetInterfaceError::PermissionError(
+                interface.name.to_owned(),
+            )),
             _ => Err(GetInterfaceError::OtherError(format!(
                 "{}: {e}",
                 &interface.name


### PR DESCRIPTION
Fixes #486

On macOS, when running `bandwhich` without elevated privileges, users see confusing error messages like:
```
lo0: No such file or directory (os error 2)
en0: No such file or directory (os error 2)
```
This happens because macOS returns `ENOENT` instead of `EPERM` when accessing BPF devices without permission.

with this PR, the program treats `ErrorKind::NotFound` as a permission error on macOS/FreeBSD, so users now see the helpful message:
```
Insufficient permissions to listen on network interface(s). Try running with sudo.
```