### PR TITLE
fix(os): handle empty error messages from pnet on bonding interfaces

### DIFF
--- a/src/os/shared.rs
+++ b/src/os/shared.rs
@@ -194,7 +194,10 @@ pub fn get_input(
                 eperm_message()
             ),
             (true, false) => format!("\n\n{}", other_errs.join("\n")),
-            (true, true) => unreachable!("Found no errors in error handling code path."),
+            (true, true) => bail!(
+                "Failed to acquire a frame receiver on any interface: unknown error. "
+                "This may occur on bonding/team interfaces or with certain network configurations."
+            ),
         };
         bail!(err_msg);
     }


### PR DESCRIPTION
When all frame receivers fail and both error lists are empty (which can occur on IEEE 802.3ad bonding/team interfaces where pnet returns errors with empty messages), the code previously hit an unreachable! panic.

Replace the panic with a graceful error message that explains the situation and mentions bonding/team interfaces as a known cause.

On systems with IEEE 802.3ad dynamic link aggregation (LACP), attempting to use bandwhich on the bonding interface or its member interfaces results in a panic instead of a user-friendly error message. The root cause is that the pnet library can return errors with empty messages on bonding interfaces, causing both error categorization lists to be empty while still entering the error handling path.