### PR TITLE
fix: resolve #360 — Unable to detect some traffic

### DIFF
--- a/src/network/connection.rs
+++ b/src/network/connection.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fmt,
+    hash::{Hash, Hasher},
     net::{IpAddr, SocketAddr},
 };
 
@@ -63,10 +64,51 @@ impl fmt::Debug for LocalSocket {
     }
 }
 
-#[derive(PartialEq, Hash, Eq, Clone, PartialOrd, Ord, Copy)]
+#[derive(Clone, Copy)]
 pub struct Connection {
     pub remote_socket: Socket,
     pub local_socket: LocalSocket,
+}
+
+impl Connection {
+    pub fn normalized_key(&self) -> (Protocol, Socket, Socket) {
+        let local_socket = Socket {
+            ip: self.local_socket.ip,
+            port: self.local_socket.port,
+        };
+
+        if local_socket <= self.remote_socket {
+            (self.local_socket.protocol, local_socket, self.remote_socket)
+        } else {
+            (self.local_socket.protocol, self.remote_socket, local_socket)
+        }
+    }
+}
+
+impl PartialEq for Connection {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalized_key() == other.normalized_key()
+    }
+}
+
+impl Eq for Connection {}
+
+impl Hash for Connection {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.normalized_key().hash(state);
+    }
+}
+
+impl PartialOrd for Connection {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Connection {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.normalized_key().cmp(&other.normalized_key())
+    }
 }
 
 impl fmt::Debug for Connection {
@@ -118,5 +160,51 @@ impl Connection {
                 protocol,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::HashMap, net::Ipv4Addr};
+
+    #[test]
+    fn connection_matches_packets_in_either_direction() {
+        let outbound = Connection::new(
+            SocketAddr::from((Ipv4Addr::new(203, 0, 113, 1), 5201)),
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            49152,
+            Protocol::Tcp,
+        );
+        let inbound = Connection::new(
+            SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 49152)),
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)),
+            5201,
+            Protocol::Tcp,
+        );
+
+        let mut connections = HashMap::new();
+        connections.insert(outbound, "iperf3");
+
+        assert_eq!(connections.get(&inbound), Some(&"iperf3"));
+    }
+
+    #[test]
+    fn connection_key_keeps_protocols_separate() {
+        let tcp = Connection::new(
+            SocketAddr::from((Ipv4Addr::new(203, 0, 113, 1), 5201)),
+            IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
+            49152,
+            Protocol::Tcp,
+        );
+        let udp = Connection::new(
+            SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 49152)),
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)),
+            5201,
+            Protocol::Udp,
+        );
+
+        assert_ne!(tcp, udp);
+        assert_ne!(tcp.normalized_key(), udp.normalized_key());
     }
 }

--- a/src/network/sniffer.rs
+++ b/src/network/sniffer.rs
@@ -42,15 +42,71 @@ pub enum Direction {
 }
 
 impl Direction {
-    pub fn new(network_interface_ips: &[IpNetwork], source: IpAddr) -> Self {
+    pub fn new(
+        network_interface_ips: &[IpNetwork],
+        source: IpAddr,
+        destination: IpAddr,
+    ) -> Option<Self> {
         if network_interface_ips
             .iter()
             .any(|ip_network| ip_network.ip() == source)
         {
-            Direction::Upload
+            Some(Direction::Upload)
+        } else if network_interface_ips
+            .iter()
+            .any(|ip_network| ip_network.ip() == destination)
+        {
+            Some(Direction::Download)
         } else {
-            Direction::Download
+            None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direction_is_upload_when_source_is_local() {
+        let network_interface_ips = vec!["192.168.1.10/24".parse().unwrap()];
+
+        assert_eq!(
+            Direction::new(
+                &network_interface_ips,
+                "192.168.1.10".parse().unwrap(),
+                "203.0.113.1".parse().unwrap(),
+            ),
+            Some(Direction::Upload)
+        );
+    }
+
+    #[test]
+    fn direction_is_download_when_destination_is_local() {
+        let network_interface_ips = vec!["192.168.1.10/24".parse().unwrap()];
+
+        assert_eq!(
+            Direction::new(
+                &network_interface_ips,
+                "203.0.113.1".parse().unwrap(),
+                "192.168.1.10".parse().unwrap(),
+            ),
+            Some(Direction::Download)
+        );
+    }
+
+    #[test]
+    fn direction_is_none_when_neither_address_is_local() {
+        let network_interface_ips = vec!["192.168.1.10/24".parse().unwrap()];
+
+        assert_eq!(
+            Direction::new(
+                &network_interface_ips,
+                "203.0.113.1".parse().unwrap(),
+                "198.51.100.1".parse().unwrap(),
+            ),
+            None
+        );
     }
 }
 
@@ -169,7 +225,11 @@ impl Sniffer {
             extract_transport_protocol!(ip_packet);
 
         let interface_name = network_interface.name.clone();
-        let direction = Direction::new(&network_interface.ips, ip_packet.get_source().into());
+        let direction = Direction::new(
+            &network_interface.ips,
+            ip_packet.get_source().into(),
+            ip_packet.get_destination().into(),
+        )?;
         let from = SocketAddr::new(ip_packet.get_source().into(), source_port);
         let to = SocketAddr::new(ip_packet.get_destination().into(), destination_port);
 

--- a/src/network/utilization.rs
+++ b/src/network/utilization.rs
@@ -9,6 +9,58 @@ pub struct ConnectionInfo {
     pub total_bytes_uploaded: u128,
 }
 
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use crate::network::{Connection, Direction, Protocol, Segment};
+
+    use super::Utilization;
+
+    fn connection(source_port: u16, destination_port: u16) -> Connection {
+        Connection {
+            source: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), source_port),
+            destination: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), destination_port),
+            protocol: Protocol::Tcp,
+        }
+    }
+
+    fn segment(connection: Connection, direction: Direction, data_length: u128) -> Segment {
+        Segment {
+            interface_name: "eth0".to_string(),
+            connection,
+            direction,
+            data_length,
+        }
+    }
+
+    #[test]
+    fn aggregates_upload_and_download_on_the_same_connection() {
+        let mut utilization = Utilization::new();
+
+        utilization.ingest(segment(connection(12345, 5201), Direction::Upload, 100));
+        utilization.ingest(segment(connection(5201, 12345), Direction::Download, 250));
+
+        assert_eq!(utilization.connections.len(), 1);
+        let connection_info = utilization.connections.values().next().unwrap();
+        assert_eq!(connection_info.total_bytes_uploaded, 100);
+        assert_eq!(connection_info.total_bytes_downloaded, 250);
+    }
+
+    #[test]
+    fn keeps_direction_counters_separate_when_connection_is_normalized() {
+        let mut utilization = Utilization::new();
+
+        utilization.ingest(segment(connection(12345, 5201), Direction::Upload, 100));
+        utilization.ingest(segment(connection(5201, 12345), Direction::Download, 250));
+        utilization.ingest(segment(connection(12345, 5201), Direction::Upload, 50));
+
+        let connection_info = utilization.connections.values().next().unwrap();
+        assert_eq!(connection_info.total_bytes_uploaded, 150);
+        assert_eq!(connection_info.total_bytes_downloaded, 250);
+    }
+}
+
 #[derive(Clone)]
 pub struct Utilization {
     pub connections: HashMap<Connection, ConnectionInfo>,
@@ -25,15 +77,16 @@ impl Utilization {
         clone
     }
     pub fn ingest(&mut self, seg: Segment) {
+        let direction = seg.direction;
         let total_bandwidth = self
             .connections
-            .entry(seg.connection)
+            .entry(seg.connection.normalized(direction))
             .or_insert(ConnectionInfo {
                 interface_name: seg.interface_name,
                 total_bytes_downloaded: 0,
                 total_bytes_uploaded: 0,
             });
-        match seg.direction {
+        match direction {
             Direction::Download => {
                 total_bandwidth.total_bytes_downloaded += seg.data_length;
             }


### PR DESCRIPTION
## Summary

Combined multi-file contribution:

## Changes

- `src/network/connection.rs`
- `src/network/sniffer.rs`
- `src/network/utilization.rs`

## Why

`src/network/connection.rs`: The iperf3 reverse-mode case indicates that packets flowing from the remote server to the local client are not being attributed to the same tracked connection as packets flowing from local to remote. This is commonly caused by treating a TCP/UDP 4-tuple as directional, eg. `(src_ip, src_port, dst_ip, dst_port)`, while process/socket lookup data is usually represented from the local endpoint perspective. For reverse traffic, the packet tuple is flipped, so lookup misses and the traffic is either ignored or counted only as unrelated control traffic.
